### PR TITLE
Fix optional setter parameter

### DIFF
--- a/src/Constraint/Typehint/TypehintResolver.php
+++ b/src/Constraint/Typehint/TypehintResolver.php
@@ -48,7 +48,7 @@ class TypehintResolver
         if ($parameter->getType()) {
             $signatureType = (string)$parameter->getType();
             if ($parameter->isOptional() && $parameter->allowsNull()) {
-                $signatureType = '?' . $signatureType;
+                $signatureType .= '|null';
             }
         } else {
             $signatureType = 'mixed';

--- a/tests/Unit/Constraint/MethodPair/data/GetOptionalSet.php
+++ b/tests/Unit/Constraint/MethodPair/data/GetOptionalSet.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\data;
+
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
+
+class GetOptionalSet implements DataInterface
+{
+    /** @var string|null */
+    private $property;
+
+    /**
+     * @return string|null
+     */
+    public function getProperty()
+    {
+        return $this->property;
+    }
+
+    public function setProperty(string $property = null): self
+    {
+        $this->property = $property;
+
+        return $this;
+    }
+
+    public function getExpectedMethodPairs(): array
+    {
+        return [['getProperty', 'setProperty', false]];
+    }
+}

--- a/tests/Unit/Constraint/Typehint/data/Optional.php
+++ b/tests/Unit/Constraint/Typehint/data/Optional.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data;
+
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\DataInterface;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Compound;
+use phpDocumentor\Reflection\Types\Integer;
+use phpDocumentor\Reflection\Types\Null_;
+
+class Optional implements DataInterface
+{
+    /**
+     * @param int|null $param
+     *
+     * @return int|null
+     */
+    public function testMethod(int $param = null)
+    {
+        return $param;
+    }
+
+    public function getExpectedType(): Type
+    {
+        return new Compound([new Integer(), new Null_()]);
+    }
+}


### PR DESCRIPTION
Fixes issue with the code:
```
    /**
     * @return string|null
     */
    public function getRemark()
    {
        return $this->remark;
    }

    public function setRemark(string $remark = null): self
    {
        $this->remark = $remark;

        return $this;
    }
```