### PR TITLE
Add support for getter to return null

### DIFF
--- a/src/Constraint/MethodPair/AccessorPair/AccessorPairProvider.php
+++ b/src/Constraint/MethodPair/AccessorPair/AccessorPairProvider.php
@@ -73,15 +73,22 @@ class AccessorPairProvider
         // Check if the getter's return typehint matches the setter's parameter typehint
         $parameter = $setterMethod->getParameters()[0];
         if ($accessorPair->hasMultiGetter() || $parameter->isVariadic()) {
-            $paramType  = (new TypehintResolver($setterMethod))->getParamTypehint($parameter);
+            $paramType  = (string)(new TypehintResolver($setterMethod))->getParamTypehint($parameter);
             $returnType = (new TypehintResolver($getterMethod))->getReturnTypehint();
 
-            return $returnType instanceof Array_ && (string)$returnType->getValueType() === (string)$paramType;
+            // The getter should return an array containing the setter's input values
+            if ($returnType instanceof Array_ && (string)$returnType->getValueType() === $paramType) {
+                return true;
+            }
+
+            // Allow getter to return typed array or null
+            return (string)$returnType === $paramType . '[]|null';
         }
 
-        $paramType  = (new TypehintResolver($setterMethod))->getParamTypehint($parameter);
-        $returnType = (new TypehintResolver($getterMethod))->getReturnTypehint();
+        $paramType  = (string)(new TypehintResolver($setterMethod))->getParamTypehint($parameter);
+        $returnType = (string)(new TypehintResolver($getterMethod))->getReturnTypehint();
 
-        return (string)$paramType === (string)$returnType;
+        // Getter should return the same value, or nullable value
+        return $paramType === $returnType || $paramType . '|null' === $returnType;
     }
 }

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/AccessorPairProviderTest.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/AccessorPairProviderTest.php
@@ -41,6 +41,9 @@ class AccessorPairProviderTest extends TestCase
         }
     }
 
+    /**
+     * @throws ReflectionException
+     */
     public function dataProvider(): Generator
     {
         yield from $this->getClassDataProvider(__DIR__ . '/data', __NAMESPACE__ . '\\data');

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/failure/GetAdd.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/failure/GetAdd.php
@@ -1,31 +1,22 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data\failure;
 
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
 
-class GetSetAdd implements DataInterface
+/**
+ * The add method receives a string, so we expect "string[]" back from getProperty.
+ * The generic "array" return type there is not accepted and should be expanded using docblock.
+ */
+class GetAdd implements DataInterface
 {
     /** @var string[] */
     private $property = [];
 
-    /**
-     * @return string[]
-     */
     public function getProperty(): array
     {
         return $this->property;
-    }
-
-    /**
-     * @param string[] $param
-     */
-    public function setProperty(array $param): self
-    {
-        $this->property = $param;
-
-        return $this;
     }
 
     public function addProperty(string $param): self
@@ -37,6 +28,6 @@ class GetSetAdd implements DataInterface
 
     public function getExpectedPairs(): array
     {
-        return [['getProperty', 'setProperty', false], ['getProperty', 'addProperty', true]];
+        return [];
     }
 }

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/failure/GetParams.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/failure/GetParams.php
@@ -1,10 +1,14 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data\failure;
 
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
 
+/**
+ * The goal of the constraint is to test if the getter returns the same value as the setter received.
+ * This can't be tested when the getter also has parameters.
+ */
 class GetParams implements DataInterface
 {
     /** @var string */

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/failure/GetSet.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/failure/GetSet.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data\failure;
+
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
+
+/**
+ * The getter returns a different type than the setter receives
+ */
+class GetSet implements DataInterface
+{
+    private $property;
+
+    public function getProperty(): bool
+    {
+        return $this->property;
+    }
+
+    public function setProperty(float $param): self
+    {
+        $this->property = $param;
+
+        return $this;
+    }
+
+    public function getExpectedPairs(): array
+    {
+        return [];
+    }
+}

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/failure/GetSetMultiParam.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/failure/GetSetMultiParam.php
@@ -1,10 +1,14 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data\failure;
 
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
 
+/**
+ * The setter has multiple parameters
+ * The constraint can't test that the received input will be correctly returned by the getter here
+ */
 class GetSetMultiParam implements DataInterface
 {
     /** @var string */

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/failure/GetVariadicSet.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/failure/GetVariadicSet.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data\failure;
+
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
+
+/**
+ * The setter receives multiple float values, but the getter returns an array of bool values
+ */
+class GetVariadicSet implements DataInterface
+{
+    /** @var bool[] */
+    private $property = [];
+
+    /**
+     * @return bool[]
+     */
+    public function getProperty(): array
+    {
+        return $this->property;
+    }
+
+    public function setProperty(float ...$param): self
+    {
+        $this->property = $param;
+
+        return $this;
+    }
+
+    public function getExpectedPairs(): array
+    {
+        return [];
+    }
+}

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetAdd.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetAdd.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data\success;
+
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
+
+class GetAdd implements DataInterface
+{
+    /** @var string[] */
+    private $property = [];
+
+    /**
+     * @return string[]
+     */
+    public function getProperty(): array
+    {
+        return $this->property;
+    }
+
+    public function addProperty(string $param): self
+    {
+        $this->property[] = $param;
+
+        return $this;
+    }
+
+    public function getExpectedPairs(): array
+    {
+        return [['getProperty', 'addProperty', true]];
+    }
+}

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetOptionalSet.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetOptionalSet.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data\success;
 
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
 

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetSet.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetSet.php
@@ -1,20 +1,21 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data\success;
 
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
 
-class GetSetTypeMismatch implements DataInterface
+class GetSet implements DataInterface
 {
+    /** @var string */
     private $property;
 
-    public function getProperty(): bool
+    public function getProperty(): string
     {
         return $this->property;
     }
 
-    public function setProperty(float $param): self
+    public function setProperty(string $param): self
     {
         $this->property = $param;
 
@@ -23,6 +24,6 @@ class GetSetTypeMismatch implements DataInterface
 
     public function getExpectedPairs(): array
     {
-        return [];
+        return [['getProperty', 'setProperty', false]];
     }
 }

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetSetAdd.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetSetAdd.php
@@ -1,11 +1,11 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data\success;
 
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
 
-class GetAdd implements DataInterface
+class GetSetAdd implements DataInterface
 {
     /** @var string[] */
     private $property = [];
@@ -18,6 +18,16 @@ class GetAdd implements DataInterface
         return $this->property;
     }
 
+    /**
+     * @param string[] $param
+     */
+    public function setProperty(array $param): self
+    {
+        $this->property = $param;
+
+        return $this;
+    }
+
     public function addProperty(string $param): self
     {
         $this->property[] = $param;
@@ -27,6 +37,6 @@ class GetAdd implements DataInterface
 
     public function getExpectedPairs(): array
     {
-        return [['getProperty', 'addProperty', true]];
+        return [['getProperty', 'setProperty', false], ['getProperty', 'addProperty', true]];
     }
 }

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetVariadicSet.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetVariadicSet.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data\success;
 
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
 
@@ -11,6 +11,7 @@ class GetVariadicSet implements DataInterface
     private $property = [];
 
     /**
+     *
      * @return string[]
      */
     public function getProperty(): array

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/NullableGetSet.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/NullableGetSet.php
@@ -1,16 +1,19 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data\success;
 
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
 
-class GetSet implements DataInterface
+class NullableGetSet implements DataInterface
 {
-    /** @var string */
+    /** @var string|null */
     private $property;
 
-    public function getProperty(): string
+    /**
+     * @return string|null
+     */
+    public function getProperty()
     {
         return $this->property;
     }

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/NullableGetVariadicSet.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/NullableGetVariadicSet.php
@@ -1,24 +1,24 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data\success;
 
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
 
-class VariadicTypeMismatch implements DataInterface
+class NullableGetVariadicSet implements DataInterface
 {
-    /** @var bool[] */
+    /** @var string[]|null */
     private $property = [];
 
     /**
-     * @return bool[]
+     * @return string[]|null
      */
     public function getProperty(): array
     {
         return $this->property;
     }
 
-    public function setProperty(float ...$param): self
+    public function setProperty(string ...$param): self
     {
         $this->property = $param;
 
@@ -27,6 +27,6 @@ class VariadicTypeMismatch implements DataInterface
 
     public function getExpectedPairs(): array
     {
-        return [];
+        return [['getProperty', 'setProperty', false]];
     }
 }


### PR DESCRIPTION
Previously a class
```php
class DataClass
{
    /** @var string|null */
    private $property;

    /**
     * @return string|null
     */
    public function getProperty()
    {
        return $this->property;
    }

    public function setProperty(string $param): self
    {
        $this->property = $param;

        return $this;
    }
}
````

would not be picked up by the AccessorPairConstraint, because of a typing mismatch between getter and setter. Now it's possible for the getter to return the setter's type OR null. The same constraint checks still apply.
The asserter would have to be executed using the $testPropertyDefaults flag in order to test the class property's default value and the getter.