### PR TITLE
New ConstraintConfig class to setup the constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,12 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \DataClass
+ * @covers ::<public>
  */
 class DataClassTest extends TestCase
 {
     use AccessorPairAsserter;
 
-    /**
-     * @covers ::<public>
-     */
     public function testDataClass()
     {
         static::assertAccessorPairs(DataClass::class);
@@ -37,17 +35,21 @@ class DataClassTest extends TestCase
 }
 ```
 
-#### Example: DataClass with getters and setters
-In this example the data class consists of getter and setter methods.
+#### Example: Simple DataClass
+In this example the data class consists of getter and setter methods and a constructor to set the properties.
 The AccessorPair constraint can match the setter methods with the getter methods and will execute tests for each pair.
+The constraint is also able to match the constructor parameters with the getter methods and will test these pairs as well.
 ```php
 class DataClass
 {
-    /** @var string */
     private $property;
-
-    /** @var bool */
     private $default;
+
+    public function __construct(string $property, bool $default)
+    {
+        $this->property = $property;
+        $this->default  = $default;
+    }
 
     public function getProperty(): string
     {
@@ -75,33 +77,84 @@ class DataClass
 }
 ```
 
-#### Example: DataClass with the constructor as a setter
-In this example the constructor is used to set the value of some properties.   
-The AccessorPair constraint can match the constructor's parameters with the getter methods and will execute tests for each pair.
+#### Example: Configuring the constraint
+In this example the constructor parameter $property will be matched with the method getProperty, and the method setProperty with getProperty.
+Because the constructor changes the data, it is not possible for the AccessorPair constraint to assert the correct working of your class.
+It is still possible to test the method pair setProperty-getProperty using the constraint config.
+
+##### The data class
 ```php
 class DataClass
 {
-    /** @var string */
     private $property;
 
-    /** @var string */
-    private $default;
+    public function __construct(string $property)
+    {
+        $this->property = strtoupper($property);
+    }
 
-    public function __construct(string $property, string $default)
+    public  function setProperty(string $property)
     {
         $this->property = $property;
-        $this->default  = $default;
     }
 
     public function getProperty(): string
     {
         return $this->property;
     }
+}
+```
 
-    public function getDefault(): string
+##### The unittest
+```php
+<?php
+
+use DigitalRevolution\AccessorPairConstraint\AccessorPairAsserter;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ConstraintConfig;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \DataClass
+ * @covers ::<public>
+ */
+class DataClassTest extends TestCase
+{
+    use AccessorPairAsserter;
+
+    public function testDataClass()
     {
-        return $this->default;
+        static::assertAccessorPairs(DataClass::class, (new ConstraintConfig())->setAssertConstructor(false));
     }
+}
+```
+
+##### Possible configuration options
+```php
+<?php
+
+class ConstraintConfig
+{
+    /**
+     * Enabled by default.
+     * Let the constraint pair all getter and setter methods,
+     * and pass test data to the setter to assert that the getter returns the exact same value.
+     */
+    public function setAssertAccessorPair(bool $assertAccessorPair);
+    
+    /**
+     * Enabled by default.
+     * Let the constraint pair the constructor's parameters with the class' getter methods.
+     * These pairs will be tested in the same ways as the getter/setter method pairs.
+     */
+    public function setAssertConstructor(bool $assertConstructor);
+    
+    /**
+     * Disabled by default.
+     * When enabled, the getter methods are called on an empty instance of the test object.
+     * This makes sure that all the properties have the correct default type,
+     * conforming the getter return typehint.
+     */
+    public function setAssertPropertyDefaults(bool $assertPropertyDefaults);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,15 @@ Optionally, the asserter can also check the initial values of all your class pro
 use DigitalRevolution\AccessorPairConstraint\AccessorPairAsserter;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @coversDefaultClass \DataClass
+ */
 class DataClassTest extends TestCase
 {
     use AccessorPairAsserter;
 
     /**
-     * @covers DataClass::<public>
+     * @covers ::<public>
      */
     public function testDataClass()
     {

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,16 @@
+# Upgrading Notes (1.x to 2.0)
+### AccessorPairAsserter::assertAccessorPairs
+Second paramater ```$testPropertyDefaults = false``` is now replaced with ```ConstraintConfig = null```.   
+The default values have the same effect as before.
+
+To upgrade:
+- If the value ```true``` was passed before, a ConstraintConfig instance with ```$propertyDefaultCheck=true``` should be passed instead
+- If the value ```false``` was passed in order to set the ```$message``` parameter, ```null``` should be passed instead for the default config
+
+### AccessorPairConstraint::__construct
+The parameter ```$testPropertyDefaults``` is replaced with ```ConstraintConfig```
+
+To upgrade:
+- If the value ```true``` was passed before, a ConstraintConfig instance with ```$assertPropertyDefaults=true``` should be passed instead
+  - i.e. ```(new ConstraintConfig())->setAssertPropertyDefaults(true)```
+- If the value ```false``` was passed before, ```null``` should be passed instead to get the default ConstraintConfig

--- a/src/AccessorPairAsserter.php
+++ b/src/AccessorPairAsserter.php
@@ -4,19 +4,23 @@ declare(strict_types=1);
 namespace DigitalRevolution\AccessorPairConstraint;
 
 use DigitalRevolution\AccessorPairConstraint\Constraint\AccessorPairConstraint;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ConstraintConfig;
 use PHPUnit\Framework\Assert;
 
 trait AccessorPairAsserter
 {
     /**
-     * @param string $object               The fully qualified name of the class that should be tested
-     * @param bool   $testPropertyDefaults When true, the getter methods are called on an empty instance of the test object.
-     *                                     This makes sure that all the properties have the correct default type,
-     *                                     conforming the getter return typehint.
-     * @param string $message              Custom PHPUnit error message in case of constraint failure
+     * @param string           $object  The fully qualified name of the class that should be tested
+     * @param ConstraintConfig $config  Configuration of the constraint.
+     *                                  By default the getter/setter pairs and constructor/getter pairs will be tested
+     * @param string           $message Custom PHPUnit error message in case of constraint failure
      */
-    public static function assertAccessorPairs(string $object, bool $testPropertyDefaults = false, string $message = '')
+    public static function assertAccessorPairs(string $object, ConstraintConfig $config = null, string $message = '')
     {
-        Assert::assertThat($object, new AccessorPairConstraint($testPropertyDefaults), $message);
+        if ($config === null) {
+            $config = new ConstraintConfig();
+        }
+
+        Assert::assertThat($object, new AccessorPairConstraint($config), $message);
     }
 }

--- a/src/Constraint/AccessorPairConstraint.php
+++ b/src/Constraint/AccessorPairConstraint.php
@@ -27,20 +27,20 @@ class AccessorPairConstraint extends Constraint
     /** @var ValueProviderFactory */
     protected $valueProviderFactory;
 
-    /** @var bool */
-    protected $testPropertyDefaults;
+    /** @var ConstraintConfig */
+    protected $config;
 
     /** @var string */
     protected $additionalFailureDesc = '';
 
-    public function __construct(bool $testPropertyDefaults)
+    public function __construct(ConstraintConfig $config)
     {
         parent::__construct();
 
         $this->accessorPairProvider    = new AccessorPairProvider();
         $this->constructorPairProvider = new ConstructorPairProvider();
         $this->valueProviderFactory    = new ValueProviderFactory();
-        $this->testPropertyDefaults    = $testPropertyDefaults;
+        $this->config                  = $config;
     }
 
     /**
@@ -59,23 +59,27 @@ class AccessorPairConstraint extends Constraint
 
         try {
             // Inspect the provided class, and fetch all accessorPairs
-            $class            = new ReflectionClass($other);
-            $accessorPairs    = $this->accessorPairProvider->getAccessorPairs($class);
-            $constructorPairs = $this->constructorPairProvider->getConstructorPairs($class);
+            $class         = new ReflectionClass($other);
+            $accessorPairs = $this->accessorPairProvider->getAccessorPairs($class);
 
-            // If requested, test the default values of all properties
-            if ($this->testPropertyDefaults) {
+            // Test the default values of all properties
+            if ($this->config->hasPropertyDefaultCheck()) {
                 $this->testPropertyDefaults($accessorPairs);
             }
 
             // Test all accessorPairs
-            foreach ($accessorPairs as $accessorPair) {
-                $this->testAccessorPair($accessorPair);
+            if ($this->config->hasAccessorPairCheck()) {
+                foreach ($accessorPairs as $accessorPair) {
+                    $this->testAccessorPair($accessorPair);
+                }
             }
 
             // Test all constructorPairs
-            foreach ($constructorPairs as $constructorPair) {
-                $this->testConstructorPair($constructorPair);
+            $constructorPairs = $this->constructorPairProvider->getConstructorPairs($class);
+            if ($this->config->hasConstructorPairCheck()) {
+                foreach ($constructorPairs as $constructorPair) {
+                    $this->testConstructorPair($constructorPair);
+                }
             }
         } catch (LogicException $e) {
             $this->fail($other, "Unable to run constraint on class. " . $e->getMessage());

--- a/src/Constraint/AccessorPairConstraint.php
+++ b/src/Constraint/AccessorPairConstraint.php
@@ -76,7 +76,7 @@ class AccessorPairConstraint extends Constraint
 
             // Test all constructorPairs
             $constructorPairs = $this->constructorPairProvider->getConstructorPairs($class);
-            if ($this->config->hasConstructorPairCheck()) {
+            if ($this->config->hasAssertConstructor()) {
                 foreach ($constructorPairs as $constructorPair) {
                     $this->testConstructorPair($constructorPair);
                 }

--- a/src/Constraint/ConstraintConfig.php
+++ b/src/Constraint/ConstraintConfig.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Constraint;
+
+class ConstraintConfig
+{
+    /** @var bool */
+    private $accessorPairCheck = true;
+
+    /** @var bool */
+    private $constructorPairCheck = true;
+
+    /** @var bool */
+    private $propertyDefaultCheck = false;
+
+    public function hasAccessorPairCheck(): bool
+    {
+        return $this->accessorPairCheck;
+    }
+
+    /**
+     * Let the constraint pair all getter and setter methods,
+     * and pass test data to the setter to assert that the getter returns the exact same value.
+     */
+    public function setAccessorPairCheck(bool $accessorPairCheck): self
+    {
+        $this->accessorPairCheck = $accessorPairCheck;
+
+        return $this;
+    }
+
+    public function hasConstructorPairCheck(): bool
+    {
+        return $this->constructorPairCheck;
+    }
+
+    /**
+     * Let the constraint pair the constructor's parameters with the class' getter methods.
+     * These pairs will be tested in the same ways as the getter/setter method pairs.
+     */
+    public function setConstructorPairCheck(bool $constructorPairCheck): self
+    {
+        $this->constructorPairCheck = $constructorPairCheck;
+
+        return $this;
+    }
+
+    public function hasPropertyDefaultCheck(): bool
+    {
+        return $this->propertyDefaultCheck;
+    }
+
+    /**
+     * When true, the getter methods are called on an empty instance of the test object.
+     * This makes sure that all the properties have the correct default type,
+     * conforming the getter return typehint.
+     */
+    public function setPropertyDefaultCheck(bool $propertyDefaultCheck): self
+    {
+        $this->propertyDefaultCheck = $propertyDefaultCheck;
+
+        return $this;
+    }
+}

--- a/src/Constraint/ConstraintConfig.php
+++ b/src/Constraint/ConstraintConfig.php
@@ -6,59 +6,62 @@ namespace DigitalRevolution\AccessorPairConstraint\Constraint;
 class ConstraintConfig
 {
     /** @var bool */
-    private $accessorPairCheck = true;
+    private $assertAccessorPair = true;
 
     /** @var bool */
-    private $constructorPairCheck = true;
+    private $assertConstructor = true;
 
     /** @var bool */
-    private $propertyDefaultCheck = false;
+    private $assertPropertyDefaults = false;
 
     public function hasAccessorPairCheck(): bool
     {
-        return $this->accessorPairCheck;
+        return $this->assertAccessorPair;
     }
 
     /**
+     * Enabled by default.
      * Let the constraint pair all getter and setter methods,
      * and pass test data to the setter to assert that the getter returns the exact same value.
      */
-    public function setAccessorPairCheck(bool $accessorPairCheck): self
+    public function setAssertAccessorPair(bool $assertAccessorPair): self
     {
-        $this->accessorPairCheck = $accessorPairCheck;
+        $this->assertAccessorPair = $assertAccessorPair;
 
         return $this;
     }
 
-    public function hasConstructorPairCheck(): bool
+    public function hasAssertConstructor(): bool
     {
-        return $this->constructorPairCheck;
+        return $this->assertConstructor;
     }
 
     /**
+     * Enabled by default.
      * Let the constraint pair the constructor's parameters with the class' getter methods.
      * These pairs will be tested in the same ways as the getter/setter method pairs.
      */
-    public function setConstructorPairCheck(bool $constructorPairCheck): self
+    public function setAssertConstructor(bool $assertConstructor): self
     {
-        $this->constructorPairCheck = $constructorPairCheck;
+        $this->assertConstructor = $assertConstructor;
 
         return $this;
     }
 
     public function hasPropertyDefaultCheck(): bool
     {
-        return $this->propertyDefaultCheck;
+        return $this->assertPropertyDefaults;
     }
 
     /**
-     * When true, the getter methods are called on an empty instance of the test object.
+     * Disabled by default.
+     * When enabled, the getter methods are called on an empty instance of the test object.
      * This makes sure that all the properties have the correct default type,
      * conforming the getter return typehint.
      */
-    public function setPropertyDefaultCheck(bool $propertyDefaultCheck): self
+    public function setAssertPropertyDefaults(bool $assertPropertyDefaults): self
     {
-        $this->propertyDefaultCheck = $propertyDefaultCheck;
+        $this->assertPropertyDefaults = $assertPropertyDefaults;
 
         return $this;
     }

--- a/tests/Integration/AccessorPairAsserterTest.php
+++ b/tests/Integration/AccessorPairAsserterTest.php
@@ -75,7 +75,7 @@ class AccessorPairAsserterTest extends TestCase
      */
     public function testMatchesSuccessInitialState($class)
     {
-        static::assertAccessorPairs(get_class($class), (new ConstraintConfig())->setPropertyDefaultCheck(true));
+        static::assertAccessorPairs(get_class($class), (new ConstraintConfig())->setAssertPropertyDefaults(true));
     }
 
     /**
@@ -87,7 +87,7 @@ class AccessorPairAsserterTest extends TestCase
      */
     public function testExcludingInitialStateCheck($class)
     {
-        static::assertAccessorPairs(get_class($class), (new ConstraintConfig())->setPropertyDefaultCheck(false));
+        static::assertAccessorPairs(get_class($class), (new ConstraintConfig())->setAssertPropertyDefaults(false));
     }
 
     /**
@@ -97,7 +97,7 @@ class AccessorPairAsserterTest extends TestCase
      */
     public function testMatchesSuccessConstructorPair($class)
     {
-        static::assertAccessorPairs(get_class($class), (new ConstraintConfig())->setConstructorPairCheck(true));
+        static::assertAccessorPairs(get_class($class), (new ConstraintConfig())->setAssertConstructor(true));
     }
 
     /**
@@ -109,7 +109,7 @@ class AccessorPairAsserterTest extends TestCase
      */
     public function testExcludingConstructorPair($class)
     {
-        static::assertAccessorPairs(get_class($class), (new ConstraintConfig())->setConstructorPairCheck(false));
+        static::assertAccessorPairs(get_class($class), (new ConstraintConfig())->setAssertConstructor(false));
     }
 
     /**
@@ -137,7 +137,7 @@ class AccessorPairAsserterTest extends TestCase
     {
         $exception = null;
         try {
-            static::assertAccessorPairs(get_class($class), (new ConstraintConfig())->setPropertyDefaultCheck(true));
+            static::assertAccessorPairs(get_class($class), (new ConstraintConfig())->setAssertPropertyDefaults(true));
         } catch (TypeError $exception) {
             static::assertRegExp('/Return value of .*?::.*?\(\) must be of the type .*?, .*? returned/', $exception->getMessage());
         }

--- a/tests/Unit/Constraint/ConstraintConfigTest.php
+++ b/tests/Unit/Constraint/ConstraintConfigTest.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Constraint;
+
+use DigitalRevolution\AccessorPairConstraint\Constraint\ConstraintConfig;
+use DigitalRevolution\AccessorPairConstraint\Tests\TestCase;
+
+/**
+ * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ConstraintConfig
+ */
+class ConstraintConfigTest extends TestCase
+{
+    /**
+     * @covers ::setAccessorPairCheck
+     * @covers ::hasAccessorPairCheck
+     * @covers ::setConstructorPairCheck
+     * @covers ::hasConstructorPairCheck
+     * @covers ::setPropertyDefaultCheck
+     * @covers ::hasPropertyDefaultCheck
+     */
+    public function testConfig()
+    {
+        $config = new ConstraintConfig();
+        static::assertTrue($config->hasAccessorPairCheck());
+        static::assertTrue($config->hasConstructorPairCheck());
+        static::assertFalse($config->hasPropertyDefaultCheck());
+
+        $config = new ConstraintConfig();
+        static::assertFalse($config->setAccessorPairCheck(false)->hasAccessorPairCheck());
+        static::assertFalse($config->setConstructorPairCheck(false)->hasConstructorPairCheck());
+        static::assertFalse($config->setPropertyDefaultCheck(false)->hasPropertyDefaultCheck());
+
+        $config = new ConstraintConfig();
+        static::assertTrue($config->setAccessorPairCheck(true)->hasAccessorPairCheck());
+        static::assertTrue($config->setConstructorPairCheck(true)->hasConstructorPairCheck());
+        static::assertTrue($config->setPropertyDefaultCheck(true)->hasPropertyDefaultCheck());
+    }
+}

--- a/tests/Unit/Constraint/ConstraintConfigTest.php
+++ b/tests/Unit/Constraint/ConstraintConfigTest.php
@@ -12,28 +12,28 @@ use DigitalRevolution\AccessorPairConstraint\Tests\TestCase;
 class ConstraintConfigTest extends TestCase
 {
     /**
-     * @covers ::setAccessorPairCheck
+     * @covers ::setAssertAccessorPair
      * @covers ::hasAccessorPairCheck
-     * @covers ::setConstructorPairCheck
-     * @covers ::hasConstructorPairCheck
-     * @covers ::setPropertyDefaultCheck
+     * @covers ::setAssertConstructor
+     * @covers ::hasAssertConstructor
+     * @covers ::setAssertPropertyDefaults
      * @covers ::hasPropertyDefaultCheck
      */
     public function testConfig()
     {
         $config = new ConstraintConfig();
         static::assertTrue($config->hasAccessorPairCheck());
-        static::assertTrue($config->hasConstructorPairCheck());
+        static::assertTrue($config->hasAssertConstructor());
         static::assertFalse($config->hasPropertyDefaultCheck());
 
         $config = new ConstraintConfig();
-        static::assertFalse($config->setAccessorPairCheck(false)->hasAccessorPairCheck());
-        static::assertFalse($config->setConstructorPairCheck(false)->hasConstructorPairCheck());
-        static::assertFalse($config->setPropertyDefaultCheck(false)->hasPropertyDefaultCheck());
+        static::assertFalse($config->setAssertAccessorPair(false)->hasAccessorPairCheck());
+        static::assertFalse($config->setAssertConstructor(false)->hasAssertConstructor());
+        static::assertFalse($config->setAssertPropertyDefaults(false)->hasPropertyDefaultCheck());
 
         $config = new ConstraintConfig();
-        static::assertTrue($config->setAccessorPairCheck(true)->hasAccessorPairCheck());
-        static::assertTrue($config->setConstructorPairCheck(true)->hasConstructorPairCheck());
-        static::assertTrue($config->setPropertyDefaultCheck(true)->hasPropertyDefaultCheck());
+        static::assertTrue($config->setAssertAccessorPair(true)->hasAccessorPairCheck());
+        static::assertTrue($config->setAssertConstructor(true)->hasAssertConstructor());
+        static::assertTrue($config->setAssertPropertyDefaults(true)->hasPropertyDefaultCheck());
     }
 }


### PR DESCRIPTION
Makes it possible to turn off the accessorpair/constructorpair tests if one of those are unwanted.

**Backward Incompatible Changes:**
AccessorPairAsserter::assertAccessorPairs
- The parameter ```$testPropertyDefaults = false``` is now replaced with ```ConstraintConfig = null```. The default values have the same effect as before
   - If the value ```true``` was passed before, a ConstraintConfig instance with ```$propertyDefaultCheck=true``` should be passed instead
   - If the value ```false``` was passed in order to set the ```$message``` parameter, ```null``` should be passed instead for the default config

AccessorPairConstraint::__construct
- The parameter ```$testPropertyDefaults``` is replaced with ```ConstraintConfig```
   - If the value ```true``` was passed before, a ConstraintConfig instance with ```$propertyDefaultCheck=true``` should be passed instead
   - If the value ```false``` was passed before, a default ConstraintConfig instance should be passed instead