### PR TITLE
Fixes the syntax: array<type, type>

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "7.0.* || 7.1.* || 7.2.* || 7.3.*",
         "phpunit/phpunit": "6.5.* || 7.5.*",
-        "phpdocumentor/type-resolver": "0.5.1"
+        "phpdocumentor/type-resolver": "0.5.* || 1.0.*"
     },
     "autoload": {
         "psr-4": {

--- a/src/Constraint/Typehint/PhpDocParser.php
+++ b/src/Constraint/Typehint/PhpDocParser.php
@@ -29,10 +29,16 @@ class PhpDocParser
      *
      * @return string|null
      */
-    public function getReturnTypehint(string $docComment)
+    public function getReturnTypehint(string $originalDocComment)
     {
+        $docComment = trim($originalDocComment);
         // empty docblock provided, no typehint found
-        if (trim($docComment) === '') {
+        if ($docComment === '') {
+            return null;
+        }
+
+        $docComment = preg_replace('/array<(.*?),\s(.*?)>/', 'array<$1,$2>', $docComment);
+        if ($docComment === null) {
             return null;
         }
 

--- a/src/Constraint/Typehint/TypehintResolver.php
+++ b/src/Constraint/Typehint/TypehintResolver.php
@@ -91,6 +91,8 @@ class TypehintResolver
             return $this->resolver->resolve($signatureType);
         }
 
+        $phpDocType = str_replace(' ', '', $phpDocType);
+
         return $this->resolver->resolve($phpDocType, $this->resolverContext);
     }
 }

--- a/tests/Integration/data/success/Regular/Types/CompoundTypes/ArrayTypedFullProperty.php
+++ b/tests/Integration/data/success/Regular/Types/CompoundTypes/ArrayTypedFullProperty.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\success\Regular\Types\CompoundTypes;
+
+class ArrayTypedFullProperty
+{
+    /** @var array<int, string> */
+    private $property = [];
+
+    /**
+     * @return array<int, string>
+     */
+    public function getProperty(): array
+    {
+        return $this->property;
+    }
+
+    /**
+     * @param array<int, string> $property
+     */
+    public function setProperty(array $property): self
+    {
+        $this->property = $property;
+
+        return $this;
+    }
+}

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/TypedFullArrayGetSet.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/TypedFullArrayGetSet.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data\success;
+
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
+
+class TypedFullArrayGetSet implements DataInterface
+{
+    /** @var array<int, string> */
+    private $property = [];
+
+    /**
+     * @return array<int, string>
+     */
+    public function getProperty()
+    {
+        return $this->property;
+    }
+
+    /**
+     * @param array<int, string> $param
+     */
+    public function setProperty(array $param): self
+    {
+        $this->property = $param;
+
+        return $this;
+    }
+
+    public function getExpectedPairs(): array
+    {
+        return [['getProperty', 'setProperty', false]];
+    }
+}

--- a/tests/Unit/Constraint/Typehint/data/ArrayTypedFull.php
+++ b/tests/Unit/Constraint/Typehint/data/ArrayTypedFull.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data;
+
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\DataInterface;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Array_;
+use phpDocumentor\Reflection\Types\String_;
+
+class ArrayTypedFull implements DataInterface
+{
+    /**
+     * @param array<string, string> $param
+     *
+     * @return array<string, string>
+     */
+    public function testMethod(array $param): array
+    {
+        return $param;
+    }
+
+    public function getExpectedType(): Type
+    {
+        return new Array_(new String_(), new String_());
+    }
+}


### PR DESCRIPTION
Added support for type-resolver v1.0 which includes support for this syntax
- Removed the spaces before sending data to the library to support type-resolver v0.5