### PR TITLE
Fix accessorpairs when the setter is private/protected (#20)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   test:

--- a/src/Constraint/MethodPair/AccessorPair/AccessorPairProvider.php
+++ b/src/Constraint/MethodPair/AccessorPair/AccessorPairProvider.php
@@ -43,6 +43,10 @@ class AccessorPairProvider
                     }
 
                     $setterMethod = $class->getMethod($setterName);
+                    if ($setterMethod->isPublic() === false) {
+                        continue;
+                    }
+
                     $accessorPair = new AccessorPair($class, $method, $setterMethod);
                     if ($this->validateAccessorPair($accessorPair)) {
                         $pairs[] = $accessorPair;

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/failure/GetPrivateSet.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/failure/GetPrivateSet.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data\failure;
+
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
+
+/**
+ * The getter method is private, so it's not possible to select the accessormethod pair
+ */
+class GetPrivateSet implements DataInterface
+{
+    /** @var string */
+    private $property = '';
+
+    private function getProperty(): string
+    {
+        return $this->property;
+    }
+
+    public function setProperty(string $param): self
+    {
+        $this->property = $param;
+
+        return $this;
+    }
+
+    public function getExpectedPairs(): array
+    {
+        return [];
+    }
+}

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/failure/GetSetPrivate.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/failure/GetSetPrivate.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data\failure;
+
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
+
+/**
+ * The setter method is private, so it's not possible to select the accessormethod pair
+ */
+class GetSetPrivate implements DataInterface
+{
+    /** @var string */
+    private $property = '';
+
+    public function getProperty(): string
+    {
+        return $this->property;
+    }
+
+    private function setProperty(string $param): self
+    {
+        $this->property = $param;
+
+        return $this;
+    }
+
+    public function getExpectedPairs(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
* Fix accessorpairs when the setter is private/protected

* Always run github workflow actions