### PR TITLE
Plural getter/add pairs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,17 +6,18 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.2",
-        "phpunit/phpunit": "^8.4 || ^9.0",
-        "phpdocumentor/type-resolver": "1.4.*"
+        "doctrine/inflector": "^2.0",
+        "phpdocumentor/type-resolver": "1.4.*",
+        "phpunit/phpunit": "^8.4 || ^9.0"
     },
     "require-dev": {
-        "roave/security-advisories": "dev-master",
-        "squizlabs/php_codesniffer": "^3.5",
         "phpmd/phpmd": "@stable",
+        "phpstan/extension-installer": "1.0.*",
         "phpstan/phpstan": "0.12.48",
         "phpstan/phpstan-phpunit": "0.12.*",
         "phpstan/phpstan-strict-rules": "0.12.*",
-        "phpstan/extension-installer": "1.0.*"
+        "roave/security-advisories": "dev-master",
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {
         "psr-4": {
@@ -27,6 +28,9 @@
         "psr-4": {
             "DigitalRevolution\\AccessorPairConstraint\\Tests\\": "tests/"
         }
+    },
+    "config": {
+        "sort-packages": true
     },
     "scripts": {
         "check": ["@check:phpstan", "@check:phpmd", "@check:phpcs"],

--- a/src/Constraint/MethodPair/AccessorPair/AccessorPairProvider.php
+++ b/src/Constraint/MethodPair/AccessorPair/AccessorPairProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace DigitalRevolution\AccessorPairConstraint\Constraint\MethodPair\AccessorPair;
 
 use DigitalRevolution\AccessorPairConstraint\Constraint\Typehint\TypehintResolver;
+use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use LogicException;
 use phpDocumentor\Reflection\Types\Array_;
 use ReflectionClass;
@@ -14,6 +16,14 @@ class AccessorPairProvider
 {
     private const GET_PREFIXES = ['get', 'is', 'has'];
     private const SET_PREFIXES = ['set', 'add'];
+
+    /** @var Inflector */
+    private $inflector;
+
+    public function __construct()
+    {
+        $this->inflector = InflectorFactory::create()->build();
+    }
 
     /**
      * Inspect the given class, using reflection, and pair all get/set methods together
@@ -61,22 +71,15 @@ class AccessorPairProvider
     }
 
     /**
-     * @return array<int, string>
+     * @return string[]
      */
     protected function getMethodBaseNames(string $methodName, string $getterPrefix): array
     {
-        $baseMethodName = substr($methodName, strlen($getterPrefix));
+        $baseMethodName  = substr($methodName, strlen($getterPrefix));
         $baseMethodNames = [$baseMethodName];
-        if (preg_match('/ies$/', $methodName) !== 0) {
-            $alternateName = preg_replace('/ies$/', 'y', $baseMethodName);
-            if (is_string($alternateName)) {
-                $baseMethodNames[] = $alternateName;
-            }
-        } elseif (preg_match('/s$/', $methodName) !== 0) {
-            $alternateName = preg_replace('/s$/', '', $baseMethodName);
-            if (is_string($alternateName)) {
-                $baseMethodNames[] = $alternateName;
-            }
+        $singular        = $this->inflector->singularize($baseMethodName);
+        if ($singular !== $baseMethodName) {
+            $baseMethodNames[] = $singular;
         }
 
         return $baseMethodNames;

--- a/src/Constraint/MethodPair/AccessorPair/AccessorPairProvider.php
+++ b/src/Constraint/MethodPair/AccessorPair/AccessorPairProvider.php
@@ -60,14 +60,23 @@ class AccessorPairProvider
         return $pairs;
     }
 
+    /**
+     * @return array<int, string>
+     */
     protected function getMethodBaseNames(string $methodName, string $getterPrefix): array
     {
         $baseMethodName = substr($methodName, strlen($getterPrefix));
         $baseMethodNames = [$baseMethodName];
         if (preg_match('/ies$/', $methodName) !== 0) {
-            $baseMethodNames[] = preg_replace('/ies$/', 'y', $baseMethodName);
+            $alternateName = preg_replace('/ies$/', 'y', $baseMethodName);
+            if (is_string($alternateName)) {
+                $baseMethodNames[] = $alternateName;
+            }
         } elseif (preg_match('/s$/', $methodName) !== 0) {
-            $baseMethodNames[] = preg_replace('/s$/', '', $baseMethodName);
+            $alternateName = preg_replace('/s$/', '', $baseMethodName);
+            if (is_string($alternateName)) {
+                $baseMethodNames[] = $alternateName;
+            }
         }
 
         return $baseMethodNames;

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/AccessorPairProviderTest.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/AccessorPairProviderTest.php
@@ -31,13 +31,13 @@ class AccessorPairProviderTest extends TestCase
         $actualPairs = $provider->getAccessorPairs(new ReflectionClass($class));
 
         $expectedPairs = $class->getExpectedPairs();
-        static::assertCount(count($expectedPairs), $actualPairs, get_class($class));
+        static::assertCount(count($expectedPairs), $actualPairs, 'Number of pairs');
         foreach ($actualPairs as $key => $actualPair) {
             $expectedPair = $expectedPairs[$key];
-            static::assertSame(get_class($class), $actualPair->getClass()->getName(), get_class($class));
-            static::assertSame($expectedPair[0], $actualPair->getGetMethod()->getName(), get_class($class));
-            static::assertSame($expectedPair[1], $actualPair->getSetMethod()->getName(), get_class($class));
-            static::assertSame($expectedPair[2], $actualPair->hasMultiGetter(), get_class($class));
+            static::assertSame(get_class($class), $actualPair->getClass()->getName(), 'Data class name');
+            static::assertSame($expectedPair[0], $actualPair->getGetMethod()->getName(), 'Getter method');
+            static::assertSame($expectedPair[1], $actualPair->getSetMethod()->getName(), 'Setter method');
+            static::assertSame($expectedPair[2], $actualPair->hasMultiGetter(), 'Multi Getter');
         }
     }
 

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/AccessorPairProviderTest.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/AccessorPairProviderTest.php
@@ -31,13 +31,13 @@ class AccessorPairProviderTest extends TestCase
         $actualPairs = $provider->getAccessorPairs(new ReflectionClass($class));
 
         $expectedPairs = $class->getExpectedPairs();
-        static::assertCount(count($expectedPairs), $actualPairs);
+        static::assertCount(count($expectedPairs), $actualPairs, get_class($class));
         foreach ($actualPairs as $key => $actualPair) {
             $expectedPair = $expectedPairs[$key];
-            static::assertSame(get_class($class), $actualPair->getClass()->getName());
-            static::assertSame($expectedPair[0], $actualPair->getGetMethod()->getName());
-            static::assertSame($expectedPair[1], $actualPair->getSetMethod()->getName());
-            static::assertSame($expectedPair[2], $actualPair->hasMultiGetter());
+            static::assertSame(get_class($class), $actualPair->getClass()->getName(), get_class($class));
+            static::assertSame($expectedPair[0], $actualPair->getGetMethod()->getName(), get_class($class));
+            static::assertSame($expectedPair[1], $actualPair->getSetMethod()->getName(), get_class($class));
+            static::assertSame($expectedPair[2], $actualPair->hasMultiGetter(), get_class($class));
         }
     }
 

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetAddChildren.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetAddChildren.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data\success;
+
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
+
+class GetAddChildren implements DataInterface
+{
+    /** @var string[] */
+    private $children = [];
+
+    /**
+     *
+     * @return string[]
+     */
+    public function getChildren(): array
+    {
+        return $this->children;
+    }
+
+    public function addChild(string $child): self
+    {
+        $this->children[] = $child;
+
+        return $this;
+    }
+
+    public function getExpectedPairs(): array
+    {
+        return [['getChildren', 'addChild', true]];
+    }
+}

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetAddPlurals.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetAddPlurals.php
@@ -30,5 +30,4 @@ class GetAddPlurals implements DataInterface
     {
         return [['getValues', 'addValue', true]];
     }
-
 }

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetAddPlurals.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetAddPlurals.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data\success;
+
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
+
+class GetAddPlurals implements DataInterface
+{
+    /** @var string[] */
+    private $values = [];
+
+    /**
+     *
+     * @return string[]
+     */
+    public function getValues(): array
+    {
+        return $this->values;
+    }
+
+    public function addValue(string $param): self
+    {
+        $this->values[] = $param;
+
+        return $this;
+    }
+
+    public function getExpectedPairs(): array
+    {
+        return [['getValues', 'addValue', true]];
+    }
+
+}

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetAddPluraly.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetAddPluraly.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data\success;
+
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
+
+/**
+ * Get/add pair for fields ending in y (plural: - ies).
+ */
+class GetAddPluraly implements DataInterface
+{
+    /** @var string[] */
+    private $properties = [];
+
+    /**
+     *
+     * @return string[]
+     */
+    public function getProperties(): array
+    {
+        return $this->properties;
+    }
+
+    public function addProperty(string $param): self
+    {
+        $this->properties[] = $param;
+
+        return $this;
+    }
+
+    public function getExpectedPairs(): array
+    {
+        return [['getProperties', 'addProperty', true]];
+    }
+
+}

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetAddPluraly.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetAddPluraly.php
@@ -33,5 +33,4 @@ class GetAddPluraly implements DataInterface
     {
         return [['getProperties', 'addProperty', true]];
     }
-
 }

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetSetAddPlural.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetSetAddPlural.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data\success;
+
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
+
+class GetSetAddPlural implements DataInterface
+{
+    /** @var string[] */
+    private $properties = [];
+
+    /**
+     * @return string[]
+     */
+    public function getProperties(): array
+    {
+        return $this->properties;
+    }
+
+    /**
+     * @param string[] $param
+     */
+    public function setProperties(array $param): self
+    {
+        $this->properties = $param;
+
+        return $this;
+    }
+
+    public function addProperty(string $param): self
+    {
+        $this->properties[] = $param;
+
+        return $this;
+    }
+
+    public function getExpectedPairs(): array
+    {
+        return [['getProperties', 'setProperties', false], ['getProperties', 'addProperty', true]];
+    }
+}

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetSetPlurals.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetSetPlurals.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data\success;
+
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
+
+class GetSetPlurals implements DataInterface
+{
+    /** @var string[] */
+    private $values = [];
+
+    /**
+     *
+     * @return string[]
+     */
+    public function getValues(): array
+    {
+        return $this->values;
+    }
+
+    /**
+     * @param string[] $values
+     */
+    public function setValues(array $values): self
+    {
+        $this->values = $values;
+
+        return $this;
+    }
+
+    public function getExpectedPairs(): array
+    {
+        return [['getValues', 'setValues', false]];
+    }
+
+}

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetSetPlurals.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetSetPlurals.php
@@ -33,5 +33,4 @@ class GetSetPlurals implements DataInterface
     {
         return [['getValues', 'setValues', false]];
     }
-
 }

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetSetPluraly.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/GetSetPluraly.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data\success;
+
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
+
+class GetSetPluraly implements DataInterface
+{
+    /** @var string[] */
+    private $properties = [];
+
+    /**
+     *
+     * @return string[]
+     */
+    public function getProperties(): array
+    {
+        return $this->properties;
+    }
+
+    /**
+     * @param string[] $properties
+     */
+    public function setProperties(array $properties): self
+    {
+        $this->properties = $properties;
+
+        return $this;
+    }
+
+    public function getExpectedPairs(): array
+    {
+        return [['getProperties', 'setProperties', false]];
+    }
+}


### PR DESCRIPTION
Add support for getter / add pairs named following English grammar rules (e.g. plural getter - `getChildren`, singular setter `addChild`). [doctrine/inflector](https://github.com/doctrine/inflector/blob/2.0.x/docs/en/index.rst) is used to singularize plural getters find their corresponding add method.

Example:
```php
class Category {
    ...
    /**
     * @return Product[]
     */
    public function getProducts(): array
    {
        return $this->products;
    }

    public function addProduct(Product $product): void
    {
        $this->products[] = $product;
    }
    ...
}
```