### PR TITLE
Fixes implementation for constructor array params

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require-dev": {
         "phpmd/phpmd": "@stable",
         "phpstan/extension-installer": "1.0.*",
-        "phpstan/phpstan": "0.12.65",
+        "phpstan/phpstan": "0.12.70",
         "phpstan/phpstan-phpunit": "0.12.*",
         "phpstan/phpstan-strict-rules": "0.12.*",
         "roave/security-advisories": "dev-master",

--- a/src/Constraint/AccessorPairConstraint.php
+++ b/src/Constraint/AccessorPairConstraint.php
@@ -186,8 +186,11 @@ class AccessorPairConstraint extends Constraint
         $instanceArgs = $this->getInstanceArgs($accessorPair->getClass());
         $instance     = $accessorPair->getClass()->newInstanceArgs(array_values($instanceArgs));
 
-        // If the constructor requires a list of this setter's param, use that as starting value
-        $addedValues  = $instanceArgs[$this->inflector->pluralize($parameter->getName())] ?? [];
+        // Try and match setItems/addItem to a constructor parameter called $items.
+        // If the match exists, use the constructor param value as starting set for getItems.
+        $setterBaseName = $accessorPair->getSetMethod()->getName();
+        $setterBaseName = substr($setterBaseName, 3);
+        $addedValues    = $instanceArgs[$this->inflector->pluralize(strtolower($setterBaseName))] ?? [];
         foreach ($testValues as $testValue) {
             // Pass test value to the instance
             $accessorPair->getSetMethod()->invoke($instance, $testValue);

--- a/src/Constraint/AccessorPairConstraint.php
+++ b/src/Constraint/AccessorPairConstraint.php
@@ -9,6 +9,8 @@ use DigitalRevolution\AccessorPairConstraint\Constraint\MethodPair\ConstructorPa
 use DigitalRevolution\AccessorPairConstraint\Constraint\MethodPair\ConstructorPair\ConstructorPairProvider;
 use DigitalRevolution\AccessorPairConstraint\Constraint\Typehint\TypehintResolver;
 use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProviderFactory;
+use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use Exception;
 use LogicException;
 use PHPUnit\Framework\Constraint\Constraint;
@@ -33,12 +35,17 @@ class AccessorPairConstraint extends Constraint
     /** @var string */
     protected $additionalFailureDesc = '';
 
+    /** @var Inflector */
+    private $inflector;
+
     public function __construct(ConstraintConfig $config)
     {
         $this->accessorPairProvider    = new AccessorPairProvider();
         $this->constructorPairProvider = new ConstructorPairProvider();
         $this->valueProviderFactory    = new ValueProviderFactory();
         $this->config                  = $config;
+
+        $this->inflector = InflectorFactory::create()->build();
     }
 
     /**
@@ -111,7 +118,8 @@ class AccessorPairConstraint extends Constraint
         $this->additionalFailureDesc = 'Testing initial state of class.';
 
         foreach ($accessorPairs as $accessorPair) {
-            $instance = $accessorPair->getClass()->newInstanceArgs($this->getInstanceArgs($accessorPair->getClass()));
+            $instanceArgs = array_values($this->getInstanceArgs($accessorPair->getClass()));
+            $instance     = $accessorPair->getClass()->newInstanceArgs($instanceArgs);
             $accessorPair->getGetMethod()->invoke($instance);
         }
     }
@@ -154,7 +162,8 @@ class AccessorPairConstraint extends Constraint
         }
 
         // Create new instance, call the setter without providing a parameter. Call the getter, and we expect the default value
-        $instance = $accessorPair->getClass()->newInstanceArgs($this->getInstanceArgs($accessorPair->getClass()));
+        $instanceArgs = array_values($this->getInstanceArgs($accessorPair->getClass()));
+        $instance     = $accessorPair->getClass()->newInstanceArgs($instanceArgs);
         $accessorPair->getSetMethod()->invoke($instance);
         $storedValue = $accessorPair->getGetMethod()->invoke($instance);
 
@@ -174,8 +183,11 @@ class AccessorPairConstraint extends Constraint
      */
     protected function testParameter(ReflectionParameter $parameter, AccessorPair $accessorPair, array $testValues): void
     {
-        $addedValues = [];
-        $instance    = $accessorPair->getClass()->newInstanceArgs($this->getInstanceArgs($accessorPair->getClass()));
+        $instanceArgs = $this->getInstanceArgs($accessorPair->getClass());
+        $instance     = $accessorPair->getClass()->newInstanceArgs(array_values($instanceArgs));
+
+        // If the constructor requires a list of this setter's param, use that as starting value
+        $addedValues  = $instanceArgs[$this->inflector->pluralize($parameter->getName())] ?? [];
         foreach ($testValues as $testValue) {
             // Pass test value to the instance
             $accessorPair->getSetMethod()->invoke($instance, $testValue);
@@ -219,7 +231,7 @@ class AccessorPairConstraint extends Constraint
             return;
         }
 
-        $arguments = $this->getInstanceArgs($class);
+        $arguments = array_values($this->getInstanceArgs($class));
 
         // Get all test values for the constructorPair parameter
         $testValues = $this->getTestValues($constructor, $constructorPair->getParameter());
@@ -277,8 +289,8 @@ class AccessorPairConstraint extends Constraint
 
         $arguments = [];
         foreach ($constructor->getParameters() as $parameter) {
-            $testValues  = $this->getTestValues($constructor, $parameter);
-            $arguments[] = $testValues[0];
+            $testValues                       = $this->getTestValues($constructor, $parameter);
+            $arguments[$parameter->getName()] = $testValues[0];
         }
 
         return $arguments;

--- a/tests/Integration/data/success/Regular/Constructor/ArrayAddProperty.php
+++ b/tests/Integration/data/success/Regular/Constructor/ArrayAddProperty.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\success\Regular\Constructor;
+
+use stdClass;
+
+class ArrayAddProperty
+{
+    /** @var stdClass[] */
+    private $items;
+
+    /**
+     * @param stdClass[] $items
+     */
+    public function __construct(array $items)
+    {
+        $this->items = $items;
+    }
+
+    public function addItem(stdClass $item): void
+    {
+        $this->items[] = $item;
+    }
+
+    /**
+     * @param stdClass[] $items
+     */
+    public function setItems(array $items): void
+    {
+        $this->items = $items;
+    }
+
+    /**
+     * @return stdClass[]
+     */
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+}

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/ArrayAddSetGet.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/data/success/ArrayAddSetGet.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\AccessorPair\data\success;
+
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
+use stdClass;
+
+class ArrayAddSetGet implements DataInterface
+{
+    /** @var stdClass[] */
+    private $items;
+
+    /**
+     * @param stdClass[] $items
+     */
+    public function __construct(array $items)
+    {
+        $this->items = $items;
+    }
+
+    public function addItem(stdClass $item): void
+    {
+        $this->items[] = $item;
+    }
+
+    /**
+     * @param stdClass[] $items
+     */
+    public function setItems(array $items): void
+    {
+        $this->items = $items;
+    }
+
+    /**
+     * @return stdClass[]
+     */
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+
+    public function getExpectedPairs(): array
+    {
+        return [['getItems', 'setItems', false], ['getItems', 'addItem', true]];
+    }
+}

--- a/tests/Unit/Constraint/MethodPair/ConstructorPair/data/ArrayAddSetGet.php
+++ b/tests/Unit/Constraint/MethodPair/ConstructorPair/data/ArrayAddSetGet.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\ConstructorPair\data;
+
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
+use stdClass;
+
+class ArrayAddSetGet implements DataInterface
+{
+    /** @var stdClass[] */
+    private $items;
+
+    /**
+     * @param stdClass[] $item
+     */
+    public function __construct(array $item)
+    {
+        $this->items = $item;
+    }
+
+    public function addItem(stdClass $item): void
+    {
+        $this->items[] = $item;
+    }
+
+    /**
+     * @param stdClass[] $items
+     */
+    public function setItems(array $items): void
+    {
+        $this->items = $items;
+    }
+
+    /**
+     * @return stdClass[]
+     */
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+
+    public function getExpectedPairs(): array
+    {
+        return [['getItems', 'item']];
+    }
+}


### PR DESCRIPTION
When the constructor has the parameter array $items, and there is an addItem and getItems method, assert that the constructor values are also returned by the getter after calling the first add method.