### PR TITLE
Fix the support for nullable optional parameters.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require-dev": {
         "phpmd/phpmd": "@stable",
         "phpstan/extension-installer": "1.0.*",
-        "phpstan/phpstan": "0.12.70",
+        "phpstan/phpstan": "0.12.75",
         "phpstan/phpstan-phpunit": "0.12.*",
         "phpstan/phpstan-strict-rules": "0.12.*",
         "roave/security-advisories": "dev-master",

--- a/src/Constraint/MethodPair/AccessorPair/AccessorPairProvider.php
+++ b/src/Constraint/MethodPair/AccessorPair/AccessorPairProvider.php
@@ -113,13 +113,13 @@ class AccessorPairProvider
             }
 
             // Allow getter to return typed array or null
-            return (string)$returnType === $paramType . '[]|null';
+            return (string)$returnType === "?" . $paramType . '[]';
         }
 
         $paramType  = (string)(new TypehintResolver($setterMethod))->getParamTypehint($parameter);
         $returnType = (string)(new TypehintResolver($getterMethod))->getReturnTypehint();
 
         // Getter should return the same value, or nullable value
-        return $paramType === $returnType || $paramType . '|null' === $returnType;
+        return $paramType === $returnType || "?" . $paramType === $returnType;
     }
 }

--- a/src/Constraint/Typehint/PhpDocParser.php
+++ b/src/Constraint/Typehint/PhpDocParser.php
@@ -55,13 +55,19 @@ class PhpDocParser
      */
     private function normalizeDocblock(string $typehint): string
     {
-        if (substr_count($typehint, "|") === 1 && strpos($typehint, "null") !== false) {
-            $typehint = preg_replace('/(^null\||\|null$)/', '', $typehint, -1, $count);
-            if ($count > 0) {
-                $typehint = "?" . $typehint;
-            }
+        if (substr_count($typehint, "|") !== 1 || strpos($typehint, "null") === false) {
+            return $typehint;
         }
 
-        return $typehint;
+        $newTypehint = preg_replace('/(^null\||\|null$)/', '', $typehint, -1, $count);
+        if ($newTypehint === null) {
+            return $typehint;
+        }
+
+        if ($count === 0) {
+            return $typehint;
+        }
+
+        return "?" . $newTypehint;
     }
 }

--- a/src/Constraint/Typehint/PhpDocParser.php
+++ b/src/Constraint/Typehint/PhpDocParser.php
@@ -55,8 +55,11 @@ class PhpDocParser
      */
     private function normalizeDocblock(string $typehint): string
     {
-        if (strpos($typehint, "|null") !== false) {
-            $typehint = "?" . str_replace("|null", "", $typehint);
+        if (substr_count($typehint, "|") === 1 && strpos($typehint, "null") !== false) {
+            $typehint = preg_replace('/(^null\||\|null$)/', '', $typehint, -1, $count);
+            if ($count > 0) {
+                $typehint = "?" . $typehint;
+            }
         }
 
         return $typehint;

--- a/src/Constraint/Typehint/PhpDocParser.php
+++ b/src/Constraint/Typehint/PhpDocParser.php
@@ -22,7 +22,7 @@ class PhpDocParser
             return null;
         }
 
-        return (string)$matches[1];
+        return $this->normalizeDocblock((string)$matches[1]);
     }
 
     /**
@@ -46,6 +46,19 @@ class PhpDocParser
             return null;
         }
 
-        return (string)$matches[1];
+        return $this->normalizeDocblock((string)$matches[1]);
+    }
+
+    /**
+     * Normalize docblock typehints to match PHPs typehints
+     * For example: turns string|null into ?string
+     */
+    private function normalizeDocblock(string $typehint): string
+    {
+        if (strpos($typehint, "|null") !== false) {
+            $typehint = "?" . str_replace("|null", "", $typehint);
+        }
+
+        return $typehint;
     }
 }

--- a/src/Constraint/Typehint/TypehintResolver.php
+++ b/src/Constraint/Typehint/TypehintResolver.php
@@ -45,8 +45,8 @@ class TypehintResolver
         $parameterType = $parameter->getType();
         if ($parameterType instanceof ReflectionNamedType) {
             $signatureType = $parameterType->getName();
-            if ($parameter->isOptional() && $parameter->allowsNull()) {
-                $signatureType .= '|null';
+            if ($parameter->allowsNull()) {
+                $signatureType = '?' . $signatureType;
             }
         } else {
             $signatureType = 'mixed';
@@ -71,6 +71,9 @@ class TypehintResolver
         $returnType = $this->method->getReturnType();
         if ($returnType instanceof ReflectionNamedType) {
             $signatureType = $returnType->getName();
+            if ($returnType->allowsNull()) {
+                $signatureType = '?' . $signatureType;
+            }
         } else {
             $signatureType = 'mixed';
         }

--- a/tests/Integration/data/success/Regular/Constructor/NullableProperty.php
+++ b/tests/Integration/data/success/Regular/Constructor/NullableProperty.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\success\Regular\Constructor;
+
+class NullableProperty
+{
+    /** @var int|null */
+    private $property;
+
+    public function __construct(?int $property = null)
+    {
+        $this->property = $property;
+    }
+
+    public function getProperty(): ?int
+    {
+        return $this->property;
+    }
+}

--- a/tests/Unit/Constraint/MethodPair/AccessorPair/AccessorPairProviderTest.php
+++ b/tests/Unit/Constraint/MethodPair/AccessorPair/AccessorPairProviderTest.php
@@ -12,6 +12,7 @@ use ReflectionException;
 
 /**
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\MethodPair\AccessorPair\AccessorPairProvider
+ * @covers ::__construct
  * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\Typehint\PhpDocParser
  * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\Typehint\TypehintResolver
  */
@@ -21,6 +22,7 @@ class AccessorPairProviderTest extends TestCase
      * @dataProvider dataProvider
      * @covers ::getAccessorPairs
      * @covers ::validateAccessorPair
+     * @covers ::getMethodBaseNames
      * @covers       \DigitalRevolution\AccessorPairConstraint\Constraint\MethodPair\AbstractMethodPair
      * @covers       \DigitalRevolution\AccessorPairConstraint\Constraint\MethodPair\AccessorPair\AccessorPair
      * @throws ReflectionException

--- a/tests/Unit/Constraint/MethodPair/ConstructorPair/ConstructorPairProviderTest.php
+++ b/tests/Unit/Constraint/MethodPair/ConstructorPair/ConstructorPairProviderTest.php
@@ -12,6 +12,7 @@ use ReflectionException;
 
 /**
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\MethodPair\ConstructorPair\ConstructorPairProvider
+ * @covers ::__construct
  * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\Typehint\PhpDocParser
  * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\Typehint\TypehintResolver
  */
@@ -21,9 +22,10 @@ class ConstructorPairProviderTest extends TestCase
      * @dataProvider dataProvider
      * @covers ::getConstructorPairs
      * @covers ::validateConstructorPair
+     * @covers ::getParameters
+     * @covers ::getMethodBaseNames
      * @covers       \DigitalRevolution\AccessorPairConstraint\Constraint\MethodPair\AbstractMethodPair
      * @covers       \DigitalRevolution\AccessorPairConstraint\Constraint\MethodPair\ConstructorPair\ConstructorPair
-     * @throws ReflectionException
      */
     public function testGetConstructorPairs(DataInterface $class): void
     {

--- a/tests/Unit/Constraint/MethodPair/ConstructorPair/data/NullableParam.php
+++ b/tests/Unit/Constraint/MethodPair/ConstructorPair/data/NullableParam.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\ConstructorPair\data;
+
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\MethodPair\DataInterface;
+
+class NullableParam implements DataInterface
+{
+    /** @var string|null */
+    private $property;
+
+    public function __construct(?string $property = null)
+    {
+        $this->property = $property;
+    }
+
+    public function getProperty(): ?string
+    {
+        return $this->property;
+    }
+
+    public function getExpectedPairs(): array
+    {
+        return [['getProperty', 'property']];
+    }
+}

--- a/tests/Unit/Constraint/Typehint/PhpDocParserTest.php
+++ b/tests/Unit/Constraint/Typehint/PhpDocParserTest.php
@@ -17,6 +17,7 @@ class PhpDocParserTest extends TestCase
      *
      * @dataProvider paramTypehintProvider
      * @covers ::getParamTypehint
+     * @covers ::normalizeDocblock
      */
     public function testGetParamTypehint(string $docComment, ?string $expectedTypehint): void
     {
@@ -29,6 +30,7 @@ class PhpDocParserTest extends TestCase
      *
      * @dataProvider returnTypehintProvider
      * @covers ::getReturnTypehint
+     * @covers ::normalizeDocblock
      */
     public function testGetReturnTypehint(string $docComment, ?string $expectedTypehint): void
     {
@@ -61,6 +63,9 @@ class PhpDocParserTest extends TestCase
 
         // Typed array typehint, int[] returned
         yield ['/** @param int[] $param */', 'int[]'];
+
+        // compound typehint with null, ?typehint returned
+        yield ['/** @param int|null $param */', '?int'];
     }
 
     /**
@@ -85,5 +90,8 @@ class PhpDocParserTest extends TestCase
 
         // Typed array typehint, int[] returned
         yield ['/** @return int[] */', 'int[]'];
+
+        // compound typehint with null, ?typehint returned
+        yield ['/** @return int|null */', '?int'];
     }
 }

--- a/tests/Unit/Constraint/Typehint/PhpDocParserTest.php
+++ b/tests/Unit/Constraint/Typehint/PhpDocParserTest.php
@@ -66,6 +66,9 @@ class PhpDocParserTest extends TestCase
 
         // compound typehint with null, ?typehint returned
         yield ['/** @param int|null $param */', '?int'];
+        yield ['/** @param null|int $param */', '?int'];
+        yield ['/** @param int|null|string $param */', 'int|null|string'];
+        yield ['/** @param int|nullo $param */', 'int|nullo'];
     }
 
     /**
@@ -93,5 +96,8 @@ class PhpDocParserTest extends TestCase
 
         // compound typehint with null, ?typehint returned
         yield ['/** @return int|null */', '?int'];
+        yield ['/** @return null|int */', '?int'];
+        yield ['/** @return int|null|string */', 'int|null|string'];
+        yield ['/** @return int|nullo */', 'int|nullo'];
     }
 }

--- a/tests/Unit/Constraint/Typehint/data/DocComment/ArrayTyped.php
+++ b/tests/Unit/Constraint/Typehint/data/DocComment/ArrayTyped.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data\DocComment;
 
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\DataInterface;
 use phpDocumentor\Reflection\Type;

--- a/tests/Unit/Constraint/Typehint/data/DocComment/ArrayTypedFull.php
+++ b/tests/Unit/Constraint/Typehint/data/DocComment/ArrayTypedFull.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data\DocComment;
 
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\DataInterface;
 use phpDocumentor\Reflection\Type;

--- a/tests/Unit/Constraint/Typehint/data/DocComment/BoolFalse.php
+++ b/tests/Unit/Constraint/Typehint/data/DocComment/BoolFalse.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data\DocComment;
 
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\DataInterface;
 use phpDocumentor\Reflection\Type;

--- a/tests/Unit/Constraint/Typehint/data/DocComment/BoolTrue.php
+++ b/tests/Unit/Constraint/Typehint/data/DocComment/BoolTrue.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data\DocComment;
 
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\DataInterface;
 use phpDocumentor\Reflection\Type;

--- a/tests/Unit/Constraint/Typehint/data/DocComment/InterfaceDocblock.php
+++ b/tests/Unit/Constraint/Typehint/data/DocComment/InterfaceDocblock.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data\DocComment;
 
 use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProvider;
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\DataInterface;

--- a/tests/Unit/Constraint/Typehint/data/DocComment/InterfacePartialAliasDocComment.php
+++ b/tests/Unit/Constraint/Typehint/data/DocComment/InterfacePartialAliasDocComment.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data\DocComment;
 
 use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider;
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\DataInterface;
@@ -9,9 +9,14 @@ use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\Object_;
 
-class InterfacePartialAlias implements DataInterface
+class InterfacePartialAliasDocComment implements DataInterface
 {
-    public function testMethod(ValueProvider\ValueProvider $param): ValueProvider\ValueProvider
+    /**
+     * @param ValueProvider\ValueProvider $param
+     *
+     * @return ValueProvider\ValueProvider
+     */
+    public function testMethod($param)
     {
         return $param;
     }

--- a/tests/Unit/Constraint/Typehint/data/DocComment/Nullable.php
+++ b/tests/Unit/Constraint/Typehint/data/DocComment/Nullable.php
@@ -1,20 +1,19 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data\DocComment;
 
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\DataInterface;
 use phpDocumentor\Reflection\Type;
-use phpDocumentor\Reflection\Types\Compound;
-use phpDocumentor\Reflection\Types\Float_;
 use phpDocumentor\Reflection\Types\Integer;
+use phpDocumentor\Reflection\Types\Nullable as NullableType;
 
-class Union implements DataInterface
+class Nullable implements DataInterface
 {
     /**
-     * @param int|float $param
+     * @param  ?int $param
      *
-     * @return int|float
+     * @return ?int
      */
     public function testMethod($param)
     {
@@ -23,6 +22,6 @@ class Union implements DataInterface
 
     public function getExpectedType(): Type
     {
-        return new Compound([new Integer(), new Float_()]);
+        return new NullableType(new Integer());
     }
 }

--- a/tests/Unit/Constraint/Typehint/data/DocComment/OptionalNull.php
+++ b/tests/Unit/Constraint/Typehint/data/DocComment/OptionalNull.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data\DocComment;
+
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\DataInterface;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Integer;
+use phpDocumentor\Reflection\Types\Nullable as NullableType;
+
+class OptionalNull implements DataInterface
+{
+    /**
+     * @return int|null
+     */
+    public function testMethod(int $param = null)
+    {
+        return $param;
+    }
+
+    public function getExpectedType(): Type
+    {
+        return new NullableType(new Integer());
+    }
+}

--- a/tests/Unit/Constraint/Typehint/data/DocComment/StringDocComment.php
+++ b/tests/Unit/Constraint/Typehint/data/DocComment/StringDocComment.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data\DocComment;
 
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\DataInterface;
 use phpDocumentor\Reflection\Type;

--- a/tests/Unit/Constraint/Typehint/data/DocComment/Union.php
+++ b/tests/Unit/Constraint/Typehint/data/DocComment/Union.php
@@ -1,26 +1,28 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data\DocComment;
 
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\DataInterface;
 use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\Compound;
+use phpDocumentor\Reflection\Types\Float_;
 use phpDocumentor\Reflection\Types\Integer;
-use phpDocumentor\Reflection\Types\Null_;
 
-class OptionalNull implements DataInterface
+class Union implements DataInterface
 {
     /**
-     * @return int|null
+     * @param int|float $param
+     *
+     * @return int|float
      */
-    public function testMethod(int $param = null)
+    public function testMethod($param)
     {
         return $param;
     }
 
     public function getExpectedType(): Type
     {
-        return new Compound([new Integer(), new Null_()]);
+        return new Compound([new Integer(), new Float_()]);
     }
 }

--- a/tests/Unit/Constraint/Typehint/data/Signature/ArraySignature.php
+++ b/tests/Unit/Constraint/Typehint/data/Signature/ArraySignature.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data\Signature;
 
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\DataInterface;
 use phpDocumentor\Reflection\Type;

--- a/tests/Unit/Constraint/Typehint/data/Signature/InterfaceImport.php
+++ b/tests/Unit/Constraint/Typehint/data/Signature/InterfaceImport.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data\Signature;
 
 use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProvider;
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\DataInterface;

--- a/tests/Unit/Constraint/Typehint/data/Signature/InterfacePartialAlias.php
+++ b/tests/Unit/Constraint/Typehint/data/Signature/InterfacePartialAlias.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data\Signature;
 
 use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider;
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\DataInterface;
@@ -9,14 +9,9 @@ use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\Object_;
 
-class InterfacePartialAliasDocComment implements DataInterface
+class InterfacePartialAlias implements DataInterface
 {
-    /**
-     * @param ValueProvider\ValueProvider $param
-     *
-     * @return ValueProvider\ValueProvider
-     */
-    public function testMethod($param)
+    public function testMethod(ValueProvider\ValueProvider $param): ValueProvider\ValueProvider
     {
         return $param;
     }

--- a/tests/Unit/Constraint/Typehint/data/Signature/Nullable.php
+++ b/tests/Unit/Constraint/Typehint/data/Signature/Nullable.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data\Signature;
 
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\DataInterface;
 use phpDocumentor\Reflection\Type;
@@ -10,12 +10,7 @@ use phpDocumentor\Reflection\Types\Nullable as NullableType;
 
 class Nullable implements DataInterface
 {
-    /**
-     * @param  ?int $param
-     *
-     * @return ?int
-     */
-    public function testMethod($param)
+    public function testMethod(?int $param): ?int
     {
         return $param;
     }

--- a/tests/Unit/Constraint/Typehint/data/Signature/OptionalInt.php
+++ b/tests/Unit/Constraint/Typehint/data/Signature/OptionalInt.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data\Signature;
 
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\DataInterface;
 use phpDocumentor\Reflection\Type;

--- a/tests/Unit/Constraint/Typehint/data/Signature/StringSignature.php
+++ b/tests/Unit/Constraint/Typehint/data/Signature/StringSignature.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data;
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\data\Signature;
 
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\Typehint\DataInterface;
 use phpDocumentor\Reflection\Type;


### PR DESCRIPTION
Turns int|null into ?int internally to match PHP typehints, so the constructorpair/accessorpair providers can match the methods and return the pairs for testing.