### PR TITLE
Add support for constructor argument callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,16 @@ class ConstraintConfig
      * conforming the getter return typehint.
      */
     public function setAssertPropertyDefaults(bool $assertPropertyDefaults);
+
+    /**
+     * Callback function to create the constructor arguments for the class under test.
+     *
+     * Test data or mocks will be used by default.
+     *
+     * @param callable(): mixed[] $callback
+     * @return $this
+     */
+    public function setConstructorCallback(callable $callback): self;
 }
 ```
 

--- a/src/Constraint/AccessorPairConstraint.php
+++ b/src/Constraint/AccessorPairConstraint.php
@@ -285,6 +285,10 @@ class AccessorPairConstraint extends Constraint
      */
     protected function getInstanceArgs(ReflectionClass $class): array
     {
+        if ($this->config->getConstructorCallback() !== null) {
+            return $this->config->getConstructorCallback()();
+        }
+
         $constructor = $class->getConstructor();
         if ($constructor === null) {
             return [];

--- a/src/Constraint/ConstraintConfig.php
+++ b/src/Constraint/ConstraintConfig.php
@@ -14,6 +14,9 @@ class ConstraintConfig
     /** @var bool */
     private $assertPropertyDefaults = false;
 
+    /** @var null|callable(): mixed[] */
+    private $constructorCallback = null;
+
     public function hasAccessorPairCheck(): bool
     {
         return $this->assertAccessorPair;
@@ -62,6 +65,26 @@ class ConstraintConfig
     public function setAssertPropertyDefaults(bool $assertPropertyDefaults): self
     {
         $this->assertPropertyDefaults = $assertPropertyDefaults;
+
+        return $this;
+    }
+
+    public function getConstructorCallback(): ?callable
+    {
+        return $this->constructorCallback;
+    }
+
+    /**
+     * Callback function to create the constructor arguments for the class under test.
+     *
+     * Test data or mocks will be used by default.
+     *
+     * @param callable(): mixed[] $callback
+     * @return $this
+     */
+    public function setConstructorCallback(callable $callback): self
+    {
+        $this->constructorCallback = $callback;
 
         return $this;
     }

--- a/tests/Integration/AccessorPairAsserterTest.php
+++ b/tests/Integration/AccessorPairAsserterTest.php
@@ -5,10 +5,11 @@ namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration;
 
 use DigitalRevolution\AccessorPairConstraint\AccessorPairAsserter;
 use DigitalRevolution\AccessorPairConstraint\Constraint\ConstraintConfig;
+use DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\manual\CustomConstructorParameters;
+use DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\manual\SetterTransformer;
 use DigitalRevolution\AccessorPairConstraint\Tests\TestCase;
 use Generator;
 use PHPUnit\Framework\ExpectationFailedException;
-use PHPUnit\Runner\Version;
 use ReflectionException;
 use TypeError;
 
@@ -117,6 +118,28 @@ class AccessorPairAsserterTest extends TestCase
         $this->expectException(TypeError::class);
         $this->expectExceptionMessageMatches('/Return value (of .*?::.*?\(\) )?must be of (the )?type .*?, .*? returned/');
         static::assertAccessorPairs(get_class($class), (new ConstraintConfig())->setAssertPropertyDefaults(true));
+    }
+
+    public function testCustomConstructorTestFailure(): void
+    {
+        // The test should fail because the SetterTransformer mock returns a different
+        // mock object in the setter.
+        $this->expectException(ExpectationFailedException::class);
+        static::assertAccessorPairs(CustomConstructorParameters::class);
+    }
+
+    public function testCustomConstructorTest(): void
+    {
+        $config = new ConstraintConfig();
+        $config->setConstructorCallback(static function (): array {
+            // Prevent the SetterTransformer from being mocked by explicitly controlling
+            // it's creation.
+            return [
+                new SetterTransformer(),
+            ];
+        });
+
+        static::assertAccessorPairs(CustomConstructorParameters::class, $config);
     }
 
     /**

--- a/tests/Integration/data/manual/CustomConstructorParameters.php
+++ b/tests/Integration/data/manual/CustomConstructorParameters.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\manual;
+
+class CustomConstructorParameters
+{
+    /** @var SetterTransformer */
+    private $transformer;
+
+    /** @var EmptyClass */
+    private $value;
+
+    public function __construct(SetterTransformer $transformer)
+    {
+        $this->transformer = $transformer;
+    }
+
+    public function setValue(EmptyClass $data): self
+    {
+        $this->value = $this->transformer->transform($data);
+
+        return $this;
+    }
+
+    public function getValue(): ?EmptyClass
+    {
+        return $this->value;
+    }
+}

--- a/tests/Integration/data/manual/EmptyClass.php
+++ b/tests/Integration/data/manual/EmptyClass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\manual;
+
+class EmptyClass
+{
+}

--- a/tests/Integration/data/manual/SetterTransformer.php
+++ b/tests/Integration/data/manual/SetterTransformer.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\manual;
+
+class SetterTransformer
+{
+    public function transform(EmptyClass $data): EmptyClass
+    {
+        return $data;
+    }
+}

--- a/tests/Unit/Constraint/ConstraintConfigTest.php
+++ b/tests/Unit/Constraint/ConstraintConfigTest.php
@@ -18,6 +18,8 @@ class ConstraintConfigTest extends TestCase
      * @covers ::hasAssertConstructor
      * @covers ::setAssertPropertyDefaults
      * @covers ::hasPropertyDefaultCheck
+     * @covers ::getConstructorCallback
+     * @covers ::setConstructorCallback
      */
     public function testConfig(): void
     {
@@ -35,5 +37,12 @@ class ConstraintConfigTest extends TestCase
         static::assertTrue($config->setAssertAccessorPair(true)->hasAccessorPairCheck());
         static::assertTrue($config->setAssertConstructor(true)->hasAssertConstructor());
         static::assertTrue($config->setAssertPropertyDefaults(true)->hasPropertyDefaultCheck());
+
+        $config = new ConstraintConfig();
+        $callback = static function (): array {
+            return [];
+        };
+        static::assertNull($config->getConstructorCallback());
+        static::assertSame($callback, $config->setConstructorCallback($callback)->getConstructorCallback());
     }
 }

--- a/tests/Unit/Constraint/ValueProvider/ValueProviderFactoryTest.php
+++ b/tests/Unit/Constraint/ValueProvider/ValueProviderFactoryTest.php
@@ -68,7 +68,7 @@ class ValueProviderFactoryTest extends TestCase
      * @covers ::getMixedProvider
      * @covers ::getProviders
      */
-    public function testGetGetProvider(Type $type, ValueProvider $expectedProvider): void
+    public function testGetProvider(Type $type, ValueProvider $expectedProvider): void
     {
         $providerFactory = new ValueProviderFactory();
         static::assertEquals($expectedProvider, $providerFactory->getProvider($type));


### PR DESCRIPTION
Sometimes it's undesireable to use mocked classes in the accessorpair
tests because mocked objects only execute based on the typehints. For
example:

Suppose a getter/setter combo in which the setter transforms the value
and sets the result:

```php
public function setValue(ValueClass $value): self
{
    $this->value = $this->integrityChecker->check($value);
    return $this;
}
```

If the integrity checker gets mocked, then the result from the `check`
function is a new object that does not match the one passed in to the
setter, which causes the accessor-pair test to fail (get/set don't
match!).

This commit allows the constructor argument to be set manually to work
around these types of mocking problems.