### PR TITLE
Add PHP 8.1 to workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0']
+        php-versions: ['7.2', '7.3', '7.4', '8.1']
         composer-flags: ['', '--prefer-lowest']
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.2
+          php-version: 7.4
           coverage: none
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.1']
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
         composer-flags: ['', '--prefer-lowest']
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.4', '8.0', '8.1']
         composer-flags: ['', '--prefer-lowest']
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%207.2-8892BF)](https://php.net/)
+[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%207.4-8892BF)](https://php.net/)
 
 # AccessorPair Constraint
 A way to automatically unit test (and cover) all getter and setters of your data class.

--- a/composer.json
+++ b/composer.json
@@ -5,19 +5,19 @@
     "license": "MIT",
     "minimum-stability": "stable",
     "require": {
-        "php": ">=7.2",
+        "php": ">=7.4",
         "doctrine/inflector": "^2.0",
         "phpdocumentor/type-resolver": "1.4.*",
-        "phpunit/phpunit": "^8.4 || ^9.2"
+        "phpunit/phpunit": "^9.0"
     },
     "require-dev": {
         "phpmd/phpmd": "@stable",
-        "phpstan/extension-installer": "1.0.*",
-        "phpstan/phpstan": "0.12.75",
+        "phpstan/extension-installer": "^1.1",
+        "phpstan/phpstan": "0.12.*",
         "phpstan/phpstan-phpunit": "0.12.*",
         "phpstan/phpstan-strict-rules": "0.12.*",
-        "roave/security-advisories": "dev-master",
-        "squizlabs/php_codesniffer": "^3.5"
+        "roave/security-advisories": "dev-latest",
+        "squizlabs/php_codesniffer": "^3.6"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": ">=7.2",
         "doctrine/inflector": "^2.0",
         "phpdocumentor/type-resolver": "1.4.*",
-        "phpunit/phpunit": "^8.4 || ^9.0"
+        "phpunit/phpunit": "^8.4 || ^9.1"
     },
     "require-dev": {
         "phpmd/phpmd": "@stable",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": ">=7.2",
         "doctrine/inflector": "^2.0",
         "phpdocumentor/type-resolver": "1.4.*",
-        "phpunit/phpunit": "^8.4 || ^9.1"
+        "phpunit/phpunit": "^8.4 || ^9.2"
     },
     "require-dev": {
         "phpmd/phpmd": "@stable",


### PR DESCRIPTION
Removes php <= 7.3, because of issues when using composer --prefer-lowest on php 8.1