### PR TITLE
Add support for extra pseudo types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=7.4",
         "doctrine/inflector": "^2.0",
-        "phpdocumentor/type-resolver": "^1.4",
+        "phpdocumentor/type-resolver": "^1.5",
         "phpunit/phpunit": "^9.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=7.4",
         "doctrine/inflector": "^2.0",
-        "phpdocumentor/type-resolver": "^1.5",
+        "phpdocumentor/type-resolver": "^1.6",
         "phpunit/phpunit": "^9.0"
     },
     "require-dev": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,3 +9,9 @@ parameters:
 
   excludePaths:
     - tests/*/data/*
+
+  # PseudoTypes supported by phpdocumentor/type-resolver but not by PHPStan
+  typeAliases:
+    html-escaped-string: 'string'
+    lowercase-string: 'string'
+    non-empty-string: 'string'

--- a/src/Constraint/ValueProvider/Compound/ArrayProvider.php
+++ b/src/Constraint/ValueProvider/Compound/ArrayProvider.php
@@ -25,7 +25,7 @@ class ArrayProvider implements ValueProvider
     {
         $keys = [];
         if ($this->keyProvider !== null) {
-            $keys = $this->keyProvider->getValues();
+            $keys = array_filter($this->keyProvider->getValues());
         }
 
         $testArray = [];

--- a/src/Constraint/ValueProvider/Compound/ArrayProvider.php
+++ b/src/Constraint/ValueProvider/Compound/ArrayProvider.php
@@ -4,38 +4,49 @@ declare(strict_types=1);
 namespace DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound;
 
 use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProvider;
+use Exception;
 
 class ArrayProvider implements ValueProvider
 {
-    /** @var ValueProvider|null */
-    protected $valueProvider;
+    protected ?ValueProvider $valueProvider;
+    protected ?ValueProvider $keyProvider;
 
-    public function __construct(ValueProvider $valueProvider = null)
+    public function __construct(ValueProvider $valueProvider = null, ValueProvider $keyProvider = null)
     {
         $this->valueProvider = $valueProvider;
+        $this->keyProvider   = $keyProvider;
     }
 
     /**
-     * @return array<int, mixed[]>
+     * @return array<string|int, mixed[]>
      * @inheritDoc
      */
     public function getValues(): array
     {
-        if ($this->valueProvider !== null) {
-            $testValues = [];
-            foreach ($this->valueProvider->getValues() as $testValue) {
-                $testValues[] = [$testValue];
-            }
-
-            return $testValues;
+        $keys = [];
+        if ($this->keyProvider !== null) {
+            $keys = $this->keyProvider->getValues();
         }
 
-        return [
-            [],
-            [1],
-            [1.0],
-            ['string'],
-            [null]
-        ];
+        $testArray = [];
+        $values    = $this->getArrayValues();
+        foreach ($values as $i => $value) {
+            $testArray[$keys[$i] ?? $i] = $value;
+        }
+
+        return [$testArray];
+    }
+
+    /**
+     * @return array<int, mixed>
+     * @throws Exception
+     */
+    protected function getArrayValues(): array
+    {
+        if ($this->valueProvider !== null) {
+            return $this->valueProvider->getValues();
+        }
+
+        return [1, 1.0, 'string', null];
     }
 }

--- a/src/Constraint/ValueProvider/NativeValueProviderFactory.php
+++ b/src/Constraint/ValueProvider/NativeValueProviderFactory.php
@@ -31,6 +31,9 @@ use phpDocumentor\Reflection\Types\String_;
 use phpDocumentor\Reflection\PseudoTypes\False_;
 use phpDocumentor\Reflection\PseudoTypes\True_;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class NativeValueProviderFactory
 {
     private ValueProviderFactory $valueProviderFactory;
@@ -68,7 +71,7 @@ class NativeValueProviderFactory
         return null;
     }
 
-    protected function getCompoundProvider(Type $typehint)
+    protected function getCompoundProvider(Type $typehint): ?ValueProvider
     {
         switch (get_class($typehint)) {
             case Array_::class:
@@ -87,7 +90,7 @@ class NativeValueProviderFactory
         }
     }
 
-    protected function getKeywordProvider(Type $typehint)
+    protected function getKeywordProvider(Type $typehint): ?ValueProvider
     {
         switch (get_class($typehint)) {
             case True_::class:
@@ -99,7 +102,7 @@ class NativeValueProviderFactory
         }
     }
 
-    protected function getScalarProvider(Type $typehint)
+    protected function getScalarProvider(Type $typehint): ?ValueProvider
     {
         switch (get_class($typehint)) {
             case Boolean::class:
@@ -115,7 +118,7 @@ class NativeValueProviderFactory
         }
     }
 
-    protected function getSpecialProvider(Type $typehint)
+    protected function getSpecialProvider(Type $typehint): ?ValueProvider
     {
         switch (get_class($typehint)) {
             case Null_::class:

--- a/src/Constraint/ValueProvider/NativeValueProviderFactory.php
+++ b/src/Constraint/ValueProvider/NativeValueProviderFactory.php
@@ -1,0 +1,148 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider;
+
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\ArrayProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\CallableProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\IterableProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\ObjectProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Keyword\FalseProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Keyword\TrueProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\BoolProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\FloatProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\IntProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\StringProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Special\NullProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Special\ResourceProvider;
+use LogicException;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Array_;
+use phpDocumentor\Reflection\Types\Boolean;
+use phpDocumentor\Reflection\Types\Callable_;
+use phpDocumentor\Reflection\Types\Float_;
+use phpDocumentor\Reflection\Types\Integer;
+use phpDocumentor\Reflection\Types\Iterable_;
+use phpDocumentor\Reflection\Types\Mixed_;
+use phpDocumentor\Reflection\Types\Null_;
+use phpDocumentor\Reflection\Types\Object_;
+use phpDocumentor\Reflection\Types\Resource_;
+use phpDocumentor\Reflection\Types\String_;
+use phpDocumentor\Reflection\PseudoTypes\False_;
+use phpDocumentor\Reflection\PseudoTypes\True_;
+
+class NativeValueProviderFactory
+{
+    private ValueProviderFactory $valueProviderFactory;
+
+    public function __construct(ValueProviderFactory $valueProviderFactory)
+    {
+        $this->valueProviderFactory = $valueProviderFactory;
+    }
+
+    /**
+     * @throws LogicException
+     */
+    public function getProvider(Type $typehint): ?ValueProvider
+    {
+        $provider = $this->getCompoundProvider($typehint);
+        if ($provider !== null) {
+            return $provider;
+        }
+
+        $provider = $this->getKeywordProvider($typehint);
+        if ($provider !== null) {
+            return $provider;
+        }
+
+        $provider = $this->getScalarProvider($typehint);
+        if ($provider !== null) {
+            return $provider;
+        }
+
+        $provider = $this->getSpecialProvider($typehint);
+        if ($provider !== null) {
+            return $provider;
+        }
+
+        return null;
+    }
+
+    protected function getCompoundProvider(Type $typehint)
+    {
+        switch (get_class($typehint)) {
+            case Array_::class:
+                return new ArrayProvider(
+                    $this->valueProviderFactory->getProvider($typehint->getValueType()),
+                    $this->valueProviderFactory->getProvider($typehint->getKeyType())
+                );
+            case Callable_::class:
+                return new CallableProvider();
+            case Iterable_::class:
+                return new IterableProvider();
+            case Object_::class:
+                return new ObjectProvider();
+            default:
+                return null;
+        }
+    }
+
+    protected function getKeywordProvider(Type $typehint)
+    {
+        switch (get_class($typehint)) {
+            case True_::class:
+                return new TrueProvider();
+            case False_::class:
+                return new FalseProvider();
+            default:
+                return null;
+        }
+    }
+
+    protected function getScalarProvider(Type $typehint)
+    {
+        switch (get_class($typehint)) {
+            case Boolean::class:
+                return new BoolProvider();
+            case Float_::class:
+                return new FloatProvider(new IntProvider());
+            case Integer::class:
+                return new IntProvider();
+            case String_::class:
+                return new StringProvider();
+            default:
+                return null;
+        }
+    }
+
+    protected function getSpecialProvider(Type $typehint)
+    {
+        switch (get_class($typehint)) {
+            case Null_::class:
+                return new NullProvider();
+            case Resource_::class:
+                return new ResourceProvider();
+            case Mixed_::class:
+                return $this->getMixedProvider();
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Return a ValueProvider returning "mixed" values
+     */
+    protected function getMixedProvider(): ValueProvider
+    {
+        return new ValueProviderList(
+            new StringProvider(),
+            new BoolProvider(),
+            new IntProvider(),
+            new FloatProvider(new IntProvider()),
+            new ArrayProvider(),
+            new ObjectProvider(),
+            new CallableProvider(),
+            new NullProvider()
+        );
+    }
+}

--- a/src/Constraint/ValueProvider/Pseudo/CallableStringProvider.php
+++ b/src/Constraint/ValueProvider/Pseudo/CallableStringProvider.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo;
+
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProvider;
+
+class CallableStringProvider implements ValueProvider
+{
+    /**
+     * @return callable-string[]
+     */
+    public function getValues(): array
+    {
+        return ['strtolower', 'array_filter'];
+    }
+}

--- a/src/Constraint/ValueProvider/Pseudo/ClassStringProvider.php
+++ b/src/Constraint/ValueProvider/Pseudo/ClassStringProvider.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo;
+
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProvider;
+use stdClass;
+
+class ClassStringProvider implements ValueProvider
+{
+    /** @var class-string|null */
+    private ?string $fqsen;
+
+    /**
+     * @param class-string|null $fqsen
+     */
+    public function __construct(?string $fqsen = null)
+    {
+        $this->fqsen = $fqsen;
+    }
+
+    /**
+     * @return class-string[]
+     */
+    public function getValues(): array
+    {
+        if ($this->fqsen !== null) {
+            return [$this->fqsen];
+        }
+
+        return [stdClass::class, self::class];
+    }
+}

--- a/src/Constraint/ValueProvider/Pseudo/HtmlEscapedStringProvider.php
+++ b/src/Constraint/ValueProvider/Pseudo/HtmlEscapedStringProvider.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo;
+
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProvider;
+
+class HtmlEscapedStringProvider implements ValueProvider
+{
+    /**
+     * @return html-escaped-string[]
+     */
+    public function getValues(): array
+    {
+        return array_map('htmlspecialchars', ['<strong>foo</strong>', '<em>bar</em>']);
+    }
+}

--- a/src/Constraint/ValueProvider/Pseudo/ListProvider.php
+++ b/src/Constraint/ValueProvider/Pseudo/ListProvider.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo;
+
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProvider;
+
+class ListProvider implements ValueProvider
+{
+    protected ?ValueProvider $valueProvider;
+
+    public function __construct(ValueProvider $valueProvider = null)
+    {
+        $this->valueProvider = $valueProvider;
+    }
+
+    /**
+     * @return array<int, array<int, mixed>>
+     * @inheritDoc
+     */
+    public function getValues(): array
+    {
+        if ($this->valueProvider !== null) {
+            $testArray = [];
+            foreach ($this->valueProvider->getValues() as $value) {
+                $testArray[] = $value;
+            }
+
+            return [$testArray];
+        }
+
+        return [[], [1], [1.0], ['string'], [null]];
+    }
+}

--- a/src/Constraint/ValueProvider/Pseudo/LiteralStringProvider.php
+++ b/src/Constraint/ValueProvider/Pseudo/LiteralStringProvider.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo;
+
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProvider;
+
+class LiteralStringProvider implements ValueProvider
+{
+    /**
+     * @return literal-string[]
+     */
+    public function getValues(): array
+    {
+        return [
+            "hello world",
+            implode(', ', ["one", "two"]),
+            implode(', ', [1, 2, 3])
+        ];
+    }
+}

--- a/src/Constraint/ValueProvider/Pseudo/LowercaseStringProvider.php
+++ b/src/Constraint/ValueProvider/Pseudo/LowercaseStringProvider.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo;
+
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\StringProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProvider;
+use Exception;
+
+class LowercaseStringProvider implements ValueProvider
+{
+    private StringProvider $stringProvider;
+
+    public function __construct(StringProvider $stringProvider)
+    {
+        $this->stringProvider = $stringProvider;
+    }
+
+    /**
+     * @return lowercase-string[]
+     * @throws Exception
+     */
+    public function getValues(): array
+    {
+        return array_map('strtolower', $this->stringProvider->getValues());
+    }
+}

--- a/src/Constraint/ValueProvider/Pseudo/NonEmptyStringProvider.php
+++ b/src/Constraint/ValueProvider/Pseudo/NonEmptyStringProvider.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo;
+
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\StringProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProvider;
+use Exception;
+
+class NonEmptyStringProvider implements ValueProvider
+{
+    /** @var LowercaseStringProvider|StringProvider */
+    private $stringProvider;
+
+    /**
+     * @param LowercaseStringProvider|StringProvider $stringProvider
+     */
+    public function __construct($stringProvider)
+    {
+        $this->stringProvider = $stringProvider;
+    }
+
+    /**
+     * @return non-empty-string[]
+     * @throws Exception
+     */
+    public function getValues(): array
+    {
+        return array_filter($this->stringProvider->getValues());
+    }
+}

--- a/src/Constraint/ValueProvider/Pseudo/NumericStringProvider.php
+++ b/src/Constraint/ValueProvider/Pseudo/NumericStringProvider.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo;
+
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProvider;
+use Exception;
+
+class NumericStringProvider implements ValueProvider
+{
+    /**
+     * @return numeric-string[]
+     * @throws Exception
+     */
+    public function getValues(): array
+    {
+        return [(string)random_int(PHP_INT_MIN, -1), (string)random_int(1, PHP_INT_MAX), '0'];
+    }
+}

--- a/src/Constraint/ValueProvider/Pseudo/TraitStringProvider.php
+++ b/src/Constraint/ValueProvider/Pseudo/TraitStringProvider.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo;
+
+use DigitalRevolution\AccessorPairConstraint\AccessorPairAsserter;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProvider;
+
+class TraitStringProvider implements ValueProvider
+{
+    /**
+     * @return trait-string[]
+     */
+    public function getValues(): array
+    {
+        return [AccessorPairAsserter::class];
+    }
+}

--- a/src/Constraint/ValueProvider/PseudoValueProviderFactory.php
+++ b/src/Constraint/ValueProvider/PseudoValueProviderFactory.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider;
+
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\CallableStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\ClassStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\HtmlEscapedStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\ListProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\LiteralStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\LowercaseStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\NonEmptyStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\NumericStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\TraitStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\FloatProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\IntProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\StringProvider;
+use LogicException;
+use phpDocumentor\Reflection\PseudoTypes\CallableString;
+use phpDocumentor\Reflection\PseudoTypes\HtmlEscapedString;
+use phpDocumentor\Reflection\PseudoTypes\IntegerRange;
+use phpDocumentor\Reflection\PseudoTypes\List_;
+use phpDocumentor\Reflection\PseudoTypes\LiteralString;
+use phpDocumentor\Reflection\PseudoTypes\LowercaseString;
+use phpDocumentor\Reflection\PseudoTypes\NegativeInteger;
+use phpDocumentor\Reflection\PseudoTypes\NonEmptyLowercaseString;
+use phpDocumentor\Reflection\PseudoTypes\NonEmptyString;
+use phpDocumentor\Reflection\PseudoTypes\Numeric_;
+use phpDocumentor\Reflection\PseudoTypes\NumericString;
+use phpDocumentor\Reflection\PseudoTypes\PositiveInteger;
+use phpDocumentor\Reflection\PseudoTypes\TraitString;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\ArrayKey;
+use phpDocumentor\Reflection\Types\ClassString;
+
+class PseudoValueProviderFactory
+{
+    private ValueProviderFactory $valueProviderFactory;
+
+    public function __construct(ValueProviderFactory $valueProviderFactory)
+    {
+        $this->valueProviderFactory = $valueProviderFactory;
+    }
+
+    /**
+     * @throws LogicException
+     */
+    public function getProvider(Type $typehint): ?ValueProvider
+    {
+        switch (get_class($typehint)) {
+            case ArrayKey::class:
+                return new ValueProviderList(new StringProvider(), new IntProvider());
+            case IntegerRange::class:
+                return new IntProvider((int)$typehint->getMinValue(), (int)$typehint->getMaxValue());
+            case List_::class:
+                return new ListProvider($this->valueProviderFactory->getProvider($typehint->getValueType()));
+            case NegativeInteger::class:
+                return new IntProvider(PHP_INT_MIN, -1);
+            case Numeric_::class:
+                return new ValueProviderList(new NumericStringProvider(), new IntProvider(), new FloatProvider(new IntProvider()));
+            case PositiveInteger::class:
+                return new IntProvider(1, PHP_INT_MAX);
+        }
+
+        return $this->getPseudoStringProvider($typehint);
+    }
+
+    protected function getPseudoStringProvider(Type $typehint): ?ValueProvider
+    {
+        switch (get_class($typehint)) {
+            case ClassString::class:
+                $fqsen = null;
+                if ($typehint->getFqsen() !== null) {
+                    /** @var class-string|null $fqsen */
+                    $fqsen = (string)$typehint->getFqsen();
+                }
+
+                return new ClassStringProvider($fqsen);
+            case CallableString::class:
+                return new CallableStringProvider();
+            case HtmlEscapedString::class:
+                return new HtmlEscapedStringProvider();
+            case LiteralString::class:
+                return new LiteralStringProvider();
+            case LowercaseString::class:
+                return new LowercaseStringProvider(new StringProvider());
+            case NonEmptyLowercaseString::class:
+                return new NonEmptyStringProvider(new LowercaseStringProvider(new StringProvider()));
+            case NonEmptyString::class:
+                return new NonEmptyStringProvider(new StringProvider());
+            case NumericString::class:
+                return new NumericStringProvider();
+            case TraitString::class:
+                return new TraitStringProvider();
+            default:
+                return null;
+        }
+    }
+}

--- a/src/Constraint/ValueProvider/PseudoValueProviderFactory.php
+++ b/src/Constraint/ValueProvider/PseudoValueProviderFactory.php
@@ -33,6 +33,9 @@ use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\ArrayKey;
 use phpDocumentor\Reflection\Types\ClassString;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class PseudoValueProviderFactory
 {
     private ValueProviderFactory $valueProviderFactory;
@@ -65,6 +68,9 @@ class PseudoValueProviderFactory
         return $this->getPseudoStringProvider($typehint);
     }
 
+    /**
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     */
     protected function getPseudoStringProvider(Type $typehint): ?ValueProvider
     {
         switch (get_class($typehint)) {

--- a/src/Constraint/ValueProvider/Scalar/IntProvider.php
+++ b/src/Constraint/ValueProvider/Scalar/IntProvider.php
@@ -8,12 +8,25 @@ use Exception;
 
 class IntProvider implements ValueProvider
 {
+    private ?int $minValue;
+    private ?int $maxValue;
+
+    public function __construct(?int $minValue = null, ?int $maxValue = null)
+    {
+        $this->minValue = $minValue;
+        $this->maxValue = $maxValue;
+    }
+
     /**
      * @return int[]
      * @throws Exception
      */
     public function getValues(): array
     {
+        if ($this->minValue !== null && $this->maxValue !== null) {
+            return [random_int($this->minValue, $this->maxValue)];
+        }
+
         return [random_int(PHP_INT_MIN, -1), random_int(1, PHP_INT_MAX), 0];
     }
 }

--- a/src/Constraint/ValueProvider/Scalar/StringProvider.php
+++ b/src/Constraint/ValueProvider/Scalar/StringProvider.php
@@ -14,6 +14,13 @@ class StringProvider implements ValueProvider
      */
     public function getValues(): array
     {
-        return [bin2hex(random_bytes(8)), bin2hex(random_bytes(16)), '✓'];
+        return [
+            bin2hex(random_bytes(8)),
+            bin2hex(random_bytes(16)),
+            strtoupper(bin2hex(random_bytes(8))),
+            strtoupper(bin2hex(random_bytes(16))),
+            '✓',
+            ''
+        ];
     }
 }

--- a/src/Constraint/ValueProvider/ValueProviderFactory.php
+++ b/src/Constraint/ValueProvider/ValueProviderFactory.php
@@ -3,66 +3,28 @@ declare(strict_types=1);
 
 namespace DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider;
 
-use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\ArrayProvider;
-use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\CallableProvider;
 use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\InstanceProvider;
-use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\IterableProvider;
-use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\ObjectProvider;
-use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Keyword\FalseProvider;
-use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Keyword\TrueProvider;
-use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\CallableStringProvider;
-use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\ClassStringProvider;
-use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\HtmlEscapedStringProvider;
-use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\ListProvider;
-use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\LiteralStringProvider;
-use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\LowercaseStringProvider;
-use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\NonEmptyStringProvider;
-use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\NumericStringProvider;
-use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\TraitStringProvider;
-use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\BoolProvider;
-use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\FloatProvider;
-use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\IntProvider;
-use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\StringProvider;
 use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Special\NullProvider;
-use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Special\ResourceProvider;
 use LogicException;
-use phpDocumentor\Reflection\PseudoTypes\CallableString;
-use phpDocumentor\Reflection\PseudoTypes\False_;
-use phpDocumentor\Reflection\PseudoTypes\HtmlEscapedString;
-use phpDocumentor\Reflection\PseudoTypes\IntegerRange;
-use phpDocumentor\Reflection\PseudoTypes\List_;
-use phpDocumentor\Reflection\PseudoTypes\LiteralString;
-use phpDocumentor\Reflection\PseudoTypes\LowercaseString;
-use phpDocumentor\Reflection\PseudoTypes\NegativeInteger;
-use phpDocumentor\Reflection\PseudoTypes\NonEmptyLowercaseString;
-use phpDocumentor\Reflection\PseudoTypes\NonEmptyString;
-use phpDocumentor\Reflection\PseudoTypes\Numeric_;
-use phpDocumentor\Reflection\PseudoTypes\NumericString;
-use phpDocumentor\Reflection\PseudoTypes\PositiveInteger;
-use phpDocumentor\Reflection\PseudoTypes\TraitString;
-use phpDocumentor\Reflection\PseudoTypes\True_;
 use phpDocumentor\Reflection\Type;
-use phpDocumentor\Reflection\Types\Array_;
-use phpDocumentor\Reflection\Types\ArrayKey;
-use phpDocumentor\Reflection\Types\Boolean;
-use phpDocumentor\Reflection\Types\Callable_;
-use phpDocumentor\Reflection\Types\ClassString;
 use phpDocumentor\Reflection\Types\Compound;
-use phpDocumentor\Reflection\Types\Float_;
-use phpDocumentor\Reflection\Types\Integer;
-use phpDocumentor\Reflection\Types\Iterable_;
-use phpDocumentor\Reflection\Types\Mixed_;
-use phpDocumentor\Reflection\Types\Null_;
 use phpDocumentor\Reflection\Types\Nullable;
 use phpDocumentor\Reflection\Types\Object_;
-use phpDocumentor\Reflection\Types\Resource_;
-use phpDocumentor\Reflection\Types\String_;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class ValueProviderFactory
 {
+    private NativeValueProviderFactory $nativeValueProviderFactory;
+    private PseudoValueProviderFactory $pseudoValueProviderFactory;
+
+    public function __construct()
+    {
+        $this->nativeValueProviderFactory = new NativeValueProviderFactory($this);
+        $this->pseudoValueProviderFactory = new PseudoValueProviderFactory($this);
+    }
+
     /**
      * Return a valueProvider based on the provided typehint
      *
@@ -86,124 +48,18 @@ class ValueProviderFactory
         }
 
         // Check if the provider typehint is a PHP scalar type
-        $scalarProvider = $this->getNativeTypeProvider($typehint);
-        if ($scalarProvider !== null) {
-            return $scalarProvider;
+        $nativeProvider = $this->nativeValueProviderFactory->getProvider($typehint);
+        if ($nativeProvider !== null) {
+            return $nativeProvider;
         }
 
         // Check if the provider typehint is a PHP pseudoType
-        $pseudoProvider = $this->getPseudoProvider($typehint);
+        $pseudoProvider = $this->pseudoValueProviderFactory->getProvider($typehint);
         if ($pseudoProvider !== null) {
             return $pseudoProvider;
         }
 
         throw new LogicException("No value provider found for typehint: " . $typehint);
-    }
-
-    /**
-     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
-     */
-    protected function getNativeTypeProvider(Type $typehint): ?ValueProvider
-    {
-        switch (get_class($typehint)) {
-            // Compound valueProviders
-            case Array_::class:
-                return new ArrayProvider($this->getProvider($typehint->getValueType()), $this->getProvider($typehint->getKeyType()));
-            case Callable_::class:
-                return new CallableProvider();
-            case Iterable_::class:
-                return new IterableProvider();
-            case Object_::class:
-                return new ObjectProvider();
-            // Keyword valueProviders
-            case True_::class:
-                return new TrueProvider();
-            case False_::class:
-                return new FalseProvider();
-            // Scalar valueProviders
-            case Boolean::class:
-                return new BoolProvider();
-            case Float_::class:
-                return new FloatProvider(new IntProvider());
-            case Integer::class:
-                return new IntProvider();
-            case String_::class:
-                return new StringProvider();
-            // Special valueProviders
-            case Null_::class:
-                return new NullProvider();
-            case Resource_::class:
-                return new ResourceProvider();
-            // Unknown/Mixed valueProviders
-            case Mixed_::class:
-                return $this->getMixedProvider();
-        }
-
-        return null;
-    }
-
-    /**
-     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
-     */
-    protected function getPseudoProvider(Type $typehint): ?ValueProvider
-    {
-        switch (get_class($typehint)) {
-            case ArrayKey::class:
-                return new ValueProviderList(new StringProvider(), new IntProvider());
-            case ClassString::class:
-                $fqsen = null;
-                if ($typehint->getFqsen() !== null) {
-                    /** @var class-string|null $fqsen */
-                    $fqsen = (string)$typehint->getFqsen();
-                }
-
-                return new ClassStringProvider($fqsen);
-            case CallableString::class:
-                return new CallableStringProvider();
-            case HtmlEscapedString::class:
-                return new HtmlEscapedStringProvider();
-            case IntegerRange::class:
-                return new IntProvider((int)$typehint->getMinValue(), (int)$typehint->getMaxValue());
-            case List_::class:
-                return new ListProvider($this->getProvider($typehint->getValueType()));
-            case LiteralString::class:
-                return new LiteralStringProvider();
-            case LowercaseString::class:
-                return new LowercaseStringProvider(new StringProvider());
-            case NegativeInteger::class:
-                return new IntProvider(PHP_INT_MIN, -1);
-            case NonEmptyLowercaseString::class:
-                return new NonEmptyStringProvider(new LowercaseStringProvider(new StringProvider()));
-            case NonEmptyString::class:
-                return new NonEmptyStringProvider(new StringProvider());
-            case Numeric_::class:
-                return new ValueProviderList(new NumericStringProvider(), new IntProvider(), new FloatProvider(new IntProvider()));
-            case NumericString::class:
-                return new NumericStringProvider();
-            case PositiveInteger::class:
-                return new IntProvider(1, PHP_INT_MAX);
-            case TraitString::class:
-                return new TraitStringProvider();
-        }
-
-        return null;
-    }
-
-    /**
-     * Return a ValueProvider returning "mixed" values
-     */
-    protected function getMixedProvider(): ValueProvider
-    {
-        return new ValueProviderList(
-            new StringProvider(),
-            new BoolProvider(),
-            new IntProvider(),
-            new FloatProvider(new IntProvider()),
-            new ArrayProvider(),
-            new ObjectProvider(),
-            new CallableProvider(),
-            new NullProvider()
-        );
     }
 
     /**

--- a/src/Constraint/ValueProvider/ValueProviderFactory.php
+++ b/src/Constraint/ValueProvider/ValueProviderFactory.php
@@ -16,13 +16,13 @@ use phpDocumentor\Reflection\Types\Object_;
  */
 class ValueProviderFactory
 {
-    private NativeValueProviderFactory $nativeValueProviderFactory;
-    private PseudoValueProviderFactory $pseudoValueProviderFactory;
+    private NativeValueProviderFactory $nativeProviderFactory;
+    private PseudoValueProviderFactory $pseudoProviderFactory;
 
     public function __construct()
     {
-        $this->nativeValueProviderFactory = new NativeValueProviderFactory($this);
-        $this->pseudoValueProviderFactory = new PseudoValueProviderFactory($this);
+        $this->nativeProviderFactory = new NativeValueProviderFactory($this);
+        $this->pseudoProviderFactory = new PseudoValueProviderFactory($this);
     }
 
     /**
@@ -48,13 +48,13 @@ class ValueProviderFactory
         }
 
         // Check if the provider typehint is a PHP scalar type
-        $nativeProvider = $this->nativeValueProviderFactory->getProvider($typehint);
+        $nativeProvider = $this->nativeProviderFactory->getProvider($typehint);
         if ($nativeProvider !== null) {
             return $nativeProvider;
         }
 
         // Check if the provider typehint is a PHP pseudoType
-        $pseudoProvider = $this->pseudoValueProviderFactory->getProvider($typehint);
+        $pseudoProvider = $this->pseudoProviderFactory->getProvider($typehint);
         if ($pseudoProvider !== null) {
             return $pseudoProvider;
         }

--- a/tests/Integration/AccessorPairAsserterTest.php
+++ b/tests/Integration/AccessorPairAsserterTest.php
@@ -47,6 +47,8 @@ use TypeError;
  * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\StringProvider
  * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Special\NullProvider
  * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Special\ResourceProvider
+ * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\NativeValueProviderFactory
+ * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\PseudoValueProviderFactory
  * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProviderList
  * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProviderFactory
  */

--- a/tests/Integration/AccessorPairAsserterTest.php
+++ b/tests/Integration/AccessorPairAsserterTest.php
@@ -18,6 +18,7 @@ use TypeError;
  * @covers \DigitalRevolution\AccessorPairConstraint\AccessorPairAsserter
  * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\ConstraintConfig
  * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\MethodPair\AbstractMethodPair
+ * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\MethodPair\ClassMethodProvider
  * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\MethodPair\AccessorPair\AccessorPair
  * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\MethodPair\AccessorPair\AccessorPairProvider
  * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\MethodPair\ConstructorPair\ConstructorPair
@@ -31,6 +32,15 @@ use TypeError;
  * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\InstanceProvider
  * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Keyword\TrueProvider
  * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Keyword\FalseProvider
+ * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\CallableStringProvider
+ * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\ClassStringProvider
+ * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\HtmlEscapedStringProvider
+ * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\ListProvider
+ * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\LiteralStringProvider
+ * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\LowercaseStringProvider
+ * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\NonEmptyStringProvider
+ * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\NumericStringProvider
+ * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\TraitStringProvider
  * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\BoolProvider
  * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\FloatProvider
  * @uses   \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\IntProvider

--- a/tests/Integration/data/success/Regular/Types/CompoundTypes/ArrayTypedFullProperty.php
+++ b/tests/Integration/data/success/Regular/Types/CompoundTypes/ArrayTypedFullProperty.php
@@ -8,6 +8,9 @@ class ArrayTypedFullProperty
     /** @var array<int, string> */
     private $property = [];
 
+    /** @var array<string, string> */
+    private $propertyB = [];
+
     /**
      * @return array<int, string>
      */
@@ -22,6 +25,24 @@ class ArrayTypedFullProperty
     public function setProperty(array $property): self
     {
         $this->property = $property;
+
+        return $this;
+    }
+
+    /**
+     * @return  array<string, string> $propertyB
+     */
+    public function getPropertyB(): array
+    {
+        return $this->propertyB;
+    }
+
+    /**
+     * @param array<string, string> $propertyB
+     */
+    public function setPropertyB(array $propertyB): self
+    {
+        $this->propertyB = $propertyB;
 
         return $this;
     }

--- a/tests/Integration/data/success/Regular/Types/PseudoTypes/ArrayKeyProperty.php
+++ b/tests/Integration/data/success/Regular/Types/PseudoTypes/ArrayKeyProperty.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\success\Regular\Types\PseudoTypes;
+
+class ArrayKeyProperty
+{
+    /** @var array-key */
+    private $property;
+
+    /**
+     * @return array-key
+     */
+    public function getProperty()
+    {
+        return $this->property;
+    }
+
+    /**
+     * @param array-key $property
+     */
+    public function setProperty($property): self
+    {
+        $this->property = $property;
+
+        return $this;
+    }
+}

--- a/tests/Integration/data/success/Regular/Types/PseudoTypes/CallableStringProperty.php
+++ b/tests/Integration/data/success/Regular/Types/PseudoTypes/CallableStringProperty.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\success\Regular\Types\PseudoTypes;
+
+class CallableStringProperty
+{
+    /** @var callable-string */
+    private string $property;
+
+    /**
+     * @return callable-string
+     */
+    public function getProperty(): string
+    {
+        return $this->property;
+    }
+
+    /**
+     * @param callable-string $property
+     */
+    public function setProperty(string $property): self
+    {
+        $this->property = $property;
+
+        return $this;
+    }
+}

--- a/tests/Integration/data/success/Regular/Types/PseudoTypes/ClassStringProperty.php
+++ b/tests/Integration/data/success/Regular/Types/PseudoTypes/ClassStringProperty.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\success\Regular\Types\PseudoTypes;
+
+class ClassStringProperty
+{
+    /** @var class-string */
+    private string $property;
+
+    /** @var class-string<ClassStringProperty> */
+    private string $propertyFqsen;
+
+    /**
+     * @return class-string
+     */
+    public function getProperty(): string
+    {
+        return $this->property;
+    }
+
+    /**
+     * @param class-string $property
+     */
+    public function setProperty(string $property): self
+    {
+        $this->property = $property;
+
+        return $this;
+    }
+
+    /**
+     * @return class-string<ClassStringProperty>
+     */
+    public function getPropertyFqsen(): string
+    {
+        return $this->propertyFqsen;
+    }
+
+    /**
+     * @param class-string<ClassStringProperty> $propertyFqsen
+     */
+    public function setPropertyFqsen(string $propertyFqsen): self
+    {
+        $this->propertyFqsen = $propertyFqsen;
+
+        return $this;
+    }
+}

--- a/tests/Integration/data/success/Regular/Types/PseudoTypes/HtmlEscapedStringProperty.php
+++ b/tests/Integration/data/success/Regular/Types/PseudoTypes/HtmlEscapedStringProperty.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\success\Regular\Types\PseudoTypes;
+
+class HtmlEscapedStringProperty
+{
+    /** @var html-escaped-string */
+    private string $property;
+
+    /**
+     * @return html-escaped-string
+     */
+    public function getProperty(): string
+    {
+        return $this->property;
+    }
+
+    /**
+     * @param html-escaped-string $property
+     */
+    public function setProperty(string $property): self
+    {
+        $this->property = $property;
+
+        return $this;
+    }
+}

--- a/tests/Integration/data/success/Regular/Types/PseudoTypes/IntegerRangeProperty.php
+++ b/tests/Integration/data/success/Regular/Types/PseudoTypes/IntegerRangeProperty.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\success\Regular\Types\PseudoTypes;
+
+class IntegerRangeProperty
+{
+    /** @var int<10,15> */
+    private int $property;
+
+    /**
+     * @return int<10,15>
+     */
+    public function getProperty(): int
+    {
+        return $this->property;
+    }
+
+    /**
+     * @param int<10,15> $property
+     */
+    public function setProperty(int $property): self
+    {
+        $this->property = $property;
+
+        return $this;
+    }
+}

--- a/tests/Integration/data/success/Regular/Types/PseudoTypes/ListProperty.php
+++ b/tests/Integration/data/success/Regular/Types/PseudoTypes/ListProperty.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\success\Regular\Types\PseudoTypes;
+
+class ListProperty
+{
+    /** @var list */
+    private array $property;
+
+    /**
+     * @return list
+     */
+    public function getProperty(): array
+    {
+        return $this->property;
+    }
+
+    /**
+     * @param list $property
+     */
+    public function setProperty(array $property): self
+    {
+        $this->property = $property;
+
+        return $this;
+    }
+}

--- a/tests/Integration/data/success/Regular/Types/PseudoTypes/ListTypedProperty.php
+++ b/tests/Integration/data/success/Regular/Types/PseudoTypes/ListTypedProperty.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\success\Regular\Types\PseudoTypes;
+
+class ListTypedProperty
+{
+    /** @var list<int> */
+    private array $property;
+
+    /**
+     * @return list<int>
+     */
+    public function getProperty(): array
+    {
+        return $this->property;
+    }
+
+    /**
+     * @param list<int> $property
+     */
+    public function setProperty(array $property): self
+    {
+        $this->property = $property;
+
+        return $this;
+    }
+}

--- a/tests/Integration/data/success/Regular/Types/PseudoTypes/LiteralStringProperty.php
+++ b/tests/Integration/data/success/Regular/Types/PseudoTypes/LiteralStringProperty.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\success\Regular\Types\PseudoTypes;
+
+class LiteralStringProperty
+{
+    /** @var literal-string */
+    private string $property;
+
+    /**
+     * @return literal-string
+     */
+    public function getProperty(): string
+    {
+        return $this->property;
+    }
+
+    /**
+     * @param literal-string $property
+     */
+    public function setProperty(string $property): self
+    {
+        $this->property = $property;
+
+        return $this;
+    }
+}

--- a/tests/Integration/data/success/Regular/Types/PseudoTypes/LowercaseStringProperty.php
+++ b/tests/Integration/data/success/Regular/Types/PseudoTypes/LowercaseStringProperty.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\success\Regular\Types\PseudoTypes;
+
+class LowercaseStringProperty
+{
+    /** @var lowercase-string */
+    private string $property;
+
+    /**
+     * @return lowercase-string
+     */
+    public function getProperty(): string
+    {
+        return $this->property;
+    }
+
+    /**
+     * @param lowercase-string $property
+     */
+    public function setProperty(string $property): self
+    {
+        $this->property = $property;
+
+        return $this;
+    }
+}

--- a/tests/Integration/data/success/Regular/Types/PseudoTypes/NegativeIntegerProperty.php
+++ b/tests/Integration/data/success/Regular/Types/PseudoTypes/NegativeIntegerProperty.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\success\Regular\Types\PseudoTypes;
+
+class NegativeIntegerProperty
+{
+    /** @var negative-int */
+    private int $property;
+
+    /**
+     * @return negative-int
+     */
+    public function getProperty(): int
+    {
+        return $this->property;
+    }
+
+    /**
+     * @param negative-int $property
+     */
+    public function setProperty(int $property): self
+    {
+        $this->property = $property;
+
+        return $this;
+    }
+}

--- a/tests/Integration/data/success/Regular/Types/PseudoTypes/NonEmptyLowercaseStringProperty.php
+++ b/tests/Integration/data/success/Regular/Types/PseudoTypes/NonEmptyLowercaseStringProperty.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\success\Regular\Types\PseudoTypes;
+
+class NonEmptyLowercaseStringProperty
+{
+    /** @var non-empty-lowercase-string */
+    private string $property;
+
+    /**
+     * @return non-empty-lowercase-string
+     */
+    public function getProperty(): string
+    {
+        return $this->property;
+    }
+
+    /**
+     * @param non-empty-lowercase-string $property
+     */
+    public function setProperty(string $property): self
+    {
+        $this->property = $property;
+
+        return $this;
+    }
+}

--- a/tests/Integration/data/success/Regular/Types/PseudoTypes/NonEmptyStringProperty.php
+++ b/tests/Integration/data/success/Regular/Types/PseudoTypes/NonEmptyStringProperty.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\success\Regular\Types\PseudoTypes;
+
+class NonEmptyStringProperty
+{
+    /** @var non-empty-string */
+    private string $property;
+
+    /**
+     * @return non-empty-string
+     */
+    public function getProperty(): string
+    {
+        return $this->property;
+    }
+
+    /**
+     * @param non-empty-string $property
+     */
+    public function setProperty(string $property): self
+    {
+        $this->property = $property;
+
+        return $this;
+    }
+}

--- a/tests/Integration/data/success/Regular/Types/PseudoTypes/NumericProperty.php
+++ b/tests/Integration/data/success/Regular/Types/PseudoTypes/NumericProperty.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\success\Regular\Types\PseudoTypes;
+
+class NumericProperty
+{
+    /** @var numeric */
+    private $property;
+
+    /**
+     * @return numeric
+     */
+    public function getProperty()
+    {
+        return $this->property;
+    }
+
+    /**
+     * @param numeric $property
+     */
+    public function setProperty($property): self
+    {
+        $this->property = $property;
+
+        return $this;
+    }
+}

--- a/tests/Integration/data/success/Regular/Types/PseudoTypes/NumericStringProperty.php
+++ b/tests/Integration/data/success/Regular/Types/PseudoTypes/NumericStringProperty.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\success\Regular\Types\PseudoTypes;
+
+class NumericStringProperty
+{
+    /** @var numeric-string */
+    private string $property;
+
+    /**
+     * @return numeric-string
+     */
+    public function getProperty(): string
+    {
+        return $this->property;
+    }
+
+    /**
+     * @param numeric-string $property
+     */
+    public function setProperty(string $property): self
+    {
+        $this->property = $property;
+
+        return $this;
+    }
+}

--- a/tests/Integration/data/success/Regular/Types/PseudoTypes/PositiveIntegerProperty.php
+++ b/tests/Integration/data/success/Regular/Types/PseudoTypes/PositiveIntegerProperty.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\success\Regular\Types\PseudoTypes;
+
+class PositiveIntegerProperty
+{
+    /** @var positive-int */
+    private int $property;
+
+    /**
+     * @return positive-int
+     */
+    public function getProperty(): int
+    {
+        return $this->property;
+    }
+
+    /**
+     * @param positive-int $property
+     */
+    public function setProperty(int $property): self
+    {
+        $this->property = $property;
+
+        return $this;
+    }
+}

--- a/tests/Integration/data/success/Regular/Types/PseudoTypes/TraitStringProperty.php
+++ b/tests/Integration/data/success/Regular/Types/PseudoTypes/TraitStringProperty.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\success\Regular\Types\PseudoTypes;
+
+class TraitStringProperty
+{
+    /** @var trait-string */
+    private string $property;
+
+    /**
+     * @return trait-string
+     */
+    public function getProperty(): string
+    {
+        return $this->property;
+    }
+
+    /**
+     * @param trait-string $property
+     */
+    public function setProperty(string $property): self
+    {
+        $this->property = $property;
+
+        return $this;
+    }
+}

--- a/tests/Unit/Constraint/ValueProvider/AbstractValueProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/AbstractValueProviderTest.php
@@ -5,6 +5,9 @@ namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValuePr
 
 use DigitalRevolution\AccessorPairConstraint\Tests\TestCase;
 
+/**
+ * @suppressWarnings(PHPMD.NumberOfChildren)
+ */
 abstract class AbstractValueProviderTest extends TestCase
 {
     abstract public function testGetValues(): void;

--- a/tests/Unit/Constraint/ValueProvider/Pseudo/CallableStringProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Pseudo/CallableStringProviderTest.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace Constraint\ValueProvider\Pseudo;
+
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\CallableStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValueProvider\AbstractValueProviderTest;
+
+/**
+ * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\CallableStringProvider
+ */
+class CallableStringProviderTest extends AbstractValueProviderTest
+{
+    /**
+     * @covers ::getValues
+     */
+    public function testGetValues(): void
+    {
+        $valueProvider = new CallableStringProvider();
+
+        static::assertValueTypes($valueProvider->getValues(), ['callable']);
+    }
+}

--- a/tests/Unit/Constraint/ValueProvider/Pseudo/ClassStringProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Pseudo/ClassStringProviderTest.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace Constraint\ValueProvider\Pseudo;
+
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\ClassStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValueProvider\AbstractValueProviderTest;
+
+/**
+ * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\ClassStringProvider
+ * @covers ::__construct
+ */
+class ClassStringProviderTest extends AbstractValueProviderTest
+{
+    /**
+     * @covers ::getValues
+     */
+    public function testGetValues(): void
+    {
+        $valueProvider = new ClassStringProvider();
+        $values        = $valueProvider->getValues();
+
+        static::assertValueTypes($values, ['string']);
+        foreach ($values as $value) {
+            static::assertTrue(class_exists($value));
+        }
+    }
+
+    /**
+     * @covers ::getValues
+     */
+    public function testGetValuesFqsen(): void
+    {
+        $valueProvider = new ClassStringProvider(self::class);
+        static::assertSame([self::class], $valueProvider->getValues());
+    }
+}

--- a/tests/Unit/Constraint/ValueProvider/Pseudo/HtmlEscapedStringProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Pseudo/HtmlEscapedStringProviderTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Constraint\ValueProvider\Pseudo;
+
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\HtmlEscapedStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValueProvider\AbstractValueProviderTest;
+use Exception;
+
+/**
+ * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\HtmlEscapedStringProvider
+ */
+class HtmlEscapedStringProviderTest extends AbstractValueProviderTest
+{
+    /**
+     * @covers ::getValues
+     * @throws Exception
+     */
+    public function testGetValues(): void
+    {
+        $valueProvider = new HtmlEscapedStringProvider();
+        $values        = $valueProvider->getValues();
+
+        static::assertValueTypes($values, ['string']);
+    }
+}

--- a/tests/Unit/Constraint/ValueProvider/Pseudo/ListProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Pseudo/ListProviderTest.php
@@ -31,7 +31,6 @@ class ListProviderTest extends AbstractValueProviderTest
     /**
      * @covers ::__construct
      * @covers ::getValues
-     * @covers ::getArrayValues
      * @throws Exception
      * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\IntProvider
      */

--- a/tests/Unit/Constraint/ValueProvider/Pseudo/ListProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Pseudo/ListProviderTest.php
@@ -1,33 +1,31 @@
 <?php
 declare(strict_types=1);
 
-namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValueProvider\Compound;
+namespace Constraint\ValueProvider\Pseudo;
 
-use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\ArrayProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\ListProvider;
 use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\IntProvider;
-use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\StringProvider;
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValueProvider\AbstractValueProviderTest;
 use Exception;
 
 /**
- * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\ArrayProvider
+ * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\ListProvider
+ * @covers ::__construct
  */
-class ArrayProviderTest extends AbstractValueProviderTest
+class ListProviderTest extends AbstractValueProviderTest
 {
     /**
-     * @covers ::__construct
      * @covers ::getValues
-     * @covers ::getArrayValues
      * @throws Exception
      */
     public function testGetValues(): void
     {
-        $valueProvider = new ArrayProvider();
+        $valueProvider = new ListProvider();
         $values        = $valueProvider->getValues();
 
         static::assertValueTypes($values, ['iterable']);
         static::assertValueTypes(array_merge(...$values), ['integer', 'double', 'string', 'NULL']);
-        static::assertValueTypes(array_keys(...$values), ['integer']);
+        static::assertValueTypes(array_keys($values), ['integer']);
     }
 
     /**
@@ -36,15 +34,14 @@ class ArrayProviderTest extends AbstractValueProviderTest
      * @covers ::getArrayValues
      * @throws Exception
      * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\IntProvider
-     * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\StringProvider
      */
     public function testGetValuesTyped(): void
     {
-        $valueProvider = new ArrayProvider(new IntProvider(), new StringProvider());
+        $valueProvider = new ListProvider(new IntProvider());
         $values        = $valueProvider->getValues();
 
         static::assertValueTypes($values, ['iterable']);
         static::assertValueTypes(array_merge(...$values), ['integer']);
-        static::assertValueTypes(array_keys(...$values), ['string']);
+        static::assertValueTypes(array_keys($values), ['integer']);
     }
 }

--- a/tests/Unit/Constraint/ValueProvider/Pseudo/LiteralStringProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Pseudo/LiteralStringProviderTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Constraint\ValueProvider\Pseudo;
+
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\LiteralStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValueProvider\AbstractValueProviderTest;
+use Exception;
+
+/**
+ * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\LiteralStringProvider
+ */
+class LiteralStringProviderTest extends AbstractValueProviderTest
+{
+    /**
+     * @covers ::getValues
+     * @throws Exception
+     */
+    public function testGetValues(): void
+    {
+        $valueProvider = new LiteralStringProvider();
+        $values        = $valueProvider->getValues();
+
+        static::assertValueTypes($values, ['string']);
+    }
+}

--- a/tests/Unit/Constraint/ValueProvider/Pseudo/LowercaseStringProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Pseudo/LowercaseStringProviderTest.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace Constraint\ValueProvider\Pseudo;
+
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\LowercaseStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\StringProvider;
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValueProvider\AbstractValueProviderTest;
+use Exception;
+
+/**
+ * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\LowercaseStringProvider
+ * @covers ::__construct
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\StringProvider
+ */
+class LowercaseStringProviderTest extends AbstractValueProviderTest
+{
+    /**
+     * @covers ::getValues
+     * @throws Exception
+     */
+    public function testGetValues(): void
+    {
+        $valueProvider = new LowercaseStringProvider(new StringProvider());
+        $values        = $valueProvider->getValues();
+
+        static::assertValueTypes($values, ['string']);
+        foreach ($values as $value) {
+            static::assertTrue(strtolower($value) === $value);
+        }
+    }
+}

--- a/tests/Unit/Constraint/ValueProvider/Pseudo/NonEmptyStringProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Pseudo/NonEmptyStringProviderTest.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace Constraint\ValueProvider\Pseudo;
+
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\NonEmptyStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\StringProvider;
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValueProvider\AbstractValueProviderTest;
+use Exception;
+
+/**
+ * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\NonEmptyStringProvider
+ * @covers ::__construct
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\StringProvider
+ */
+class NonEmptyStringProviderTest extends AbstractValueProviderTest
+{
+    /**
+     * @covers ::getValues
+     * @throws Exception
+     */
+    public function testGetValues(): void
+    {
+        $valueProvider = new NonEmptyStringProvider(new StringProvider());
+        $values        = $valueProvider->getValues();
+
+        static::assertValueTypes($values, ['string']);
+        foreach ($values as $value) {
+            static::assertNotEmpty($value);
+        }
+    }
+}

--- a/tests/Unit/Constraint/ValueProvider/Pseudo/NumericStringProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Pseudo/NumericStringProviderTest.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Constraint\ValueProvider\Pseudo;
+
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\NumericStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValueProvider\AbstractValueProviderTest;
+use Exception;
+
+/**
+ * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\NumericStringProvider
+ */
+class NumericStringProviderTest extends AbstractValueProviderTest
+{
+    /**
+     * @covers ::getValues
+     * @throws Exception
+     */
+    public function testGetValues(): void
+    {
+        $valueProvider = new NumericStringProvider();
+        $values = $valueProvider->getValues();
+
+        static::assertValueTypes($values, ['string']);
+        static::assertContainsOnly('numeric', $values);
+    }
+}

--- a/tests/Unit/Constraint/ValueProvider/Pseudo/TraitStringProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Pseudo/TraitStringProviderTest.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Constraint\ValueProvider\Pseudo;
+
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\TraitStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValueProvider\AbstractValueProviderTest;
+
+/**
+ * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\TraitStringProvider
+ */
+class TraitStringProviderTest extends AbstractValueProviderTest
+{
+    /**
+     * @covers ::getValues
+     */
+    public function testGetValues(): void
+    {
+        $valueProvider = new TraitStringProvider();
+        $values        = $valueProvider->getValues();
+
+        static::assertValueTypes($values, ['string']);
+        foreach ($values as $value) {
+            static::assertTrue(trait_exists($value));
+        }
+    }
+}

--- a/tests/Unit/Constraint/ValueProvider/PseudoValueProviderFactoryTest.php
+++ b/tests/Unit/Constraint/ValueProvider/PseudoValueProviderFactoryTest.php
@@ -1,0 +1,154 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValueProvider;
+
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\ArrayProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\CallableProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\ObjectProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\CallableStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\ClassStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\HtmlEscapedStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\ListProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\LiteralStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\LowercaseStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\NonEmptyStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\NumericStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\TraitStringProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\PseudoValueProviderFactory;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\BoolProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\FloatProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\IntProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\StringProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Special\NullProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProvider;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProviderFactory;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProviderList;
+use DigitalRevolution\AccessorPairConstraint\Tests\TestCase;
+use Generator;
+use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\PseudoTypes\CallableString;
+use phpDocumentor\Reflection\PseudoTypes\HtmlEscapedString;
+use phpDocumentor\Reflection\PseudoTypes\IntegerRange;
+use phpDocumentor\Reflection\PseudoTypes\List_;
+use phpDocumentor\Reflection\PseudoTypes\LiteralString;
+use phpDocumentor\Reflection\PseudoTypes\LowercaseString;
+use phpDocumentor\Reflection\PseudoTypes\NegativeInteger;
+use phpDocumentor\Reflection\PseudoTypes\NonEmptyLowercaseString;
+use phpDocumentor\Reflection\PseudoTypes\NonEmptyString;
+use phpDocumentor\Reflection\PseudoTypes\Numeric_;
+use phpDocumentor\Reflection\PseudoTypes\NumericString;
+use phpDocumentor\Reflection\PseudoTypes\PositiveInteger;
+use phpDocumentor\Reflection\PseudoTypes\TraitString;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\ArrayKey;
+use phpDocumentor\Reflection\Types\ClassString;
+/**
+ * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\PseudoValueProviderFactory
+ * @covers ::__construct
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\ArrayProvider
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\CallableProvider
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\IterableProvider
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\ObjectProvider
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\InstanceProvider
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Keyword\TrueProvider
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Keyword\FalseProvider
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\CallableStringProvider
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\ClassStringProvider
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\HtmlEscapedStringProvider
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\ListProvider
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\LiteralStringProvider
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\LowercaseStringProvider
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\NonEmptyStringProvider
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\NumericStringProvider
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\TraitStringProvider
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\BoolProvider
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\FloatProvider
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\IntProvider
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\StringProvider
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Special\NullProvider
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Special\ResourceProvider
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProviderList
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\NativeValueProviderFactory
+ * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProviderFactory
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class PseudoValueProviderFactoryTest extends TestCase
+{
+    /**
+     * @dataProvider pseudoTypeProvider
+     * @covers ::getProvider
+     * @covers ::getPseudoStringProvider
+     */
+    public function testGetProvider(Type $type, ValueProvider $expectedProvider): void
+    {
+        $providerFactory = new PseudoValueProviderFactory(new ValueProviderFactory());
+        static::assertEquals($expectedProvider, $providerFactory->getProvider($type));
+    }
+
+    /**
+     * @covers ::getProvider
+     * @covers ::getPseudoStringProvider
+     */
+    public function testGetProviderUnknown(): void
+    {
+        $providerFactory = new PseudoValueProviderFactory($this->createMock(ValueProviderFactory::class));
+
+        static::assertNull(
+            $providerFactory->getProvider(
+                new class implements Type {
+                    public function __toString(): string
+                    {
+                        return 'unknown';
+                    }
+                }
+            )
+        );
+    }
+
+    /**
+     * @return Generator<string, array{0: Type, 1: ValueProvider}>
+     */
+    public function pseudoTypeProvider(): Generator
+    {
+        yield "PseudoType ArrayKey" => [new ArrayKey(), new ValueProviderList(new StringProvider(), new IntProvider())];
+        yield "PseudoType ClassString" => [new ClassString(), new ClassStringProvider()];
+        yield "PseudoType ClassString Fqsen" => [
+            new ClassString(new Fqsen('\\' . ValueProvider::class)),
+            new ClassStringProvider('\\' . ValueProvider::class)
+        ];
+        yield "PseudoType CallableString" => [new CallableString(), new CallableStringProvider()];
+        yield "PseudoType HtmlEscapedString" => [new HtmlEscapedString(), new HtmlEscapedStringProvider()];
+        yield "PseudoType IntegerRange" => [new IntegerRange('0', '5'), new IntProvider(0, 5)];
+        yield "PseudoType List" => [new List_(), new ListProvider($this->getMixedProvider())];
+        yield "PseudoType LiteralString" => [new LiteralString(), new LiteralStringProvider()];
+        yield "PseudoType LowercaseString" => [new LowercaseString(), new LowercaseStringProvider(new StringProvider())];
+        yield "PseudoType NegativeInteger" => [new NegativeInteger(), new IntProvider(PHP_INT_MIN, -1)];
+        yield "PseudoType NonEmptyLowercaseString" => [
+            new NonEmptyLowercaseString(),
+            new NonEmptyStringProvider(new LowercaseStringProvider(new StringProvider()))
+        ];
+        yield "PseudoType NonEmptyString" => [new NonEmptyString(), new NonEmptyStringProvider(new StringProvider())];
+        yield "PseudoType Numeric" => [
+            new Numeric_(),
+            new ValueProviderList(new NumericStringProvider(), new IntProvider(), new FloatProvider(new IntProvider()))
+        ];
+        yield "PseudoType NumericString" => [new NumericString(), new NumericStringProvider()];
+        yield "PseudoType PositiveInteger" => [new PositiveInteger(), new IntProvider(1, PHP_INT_MAX)];
+        yield "PseudoType TraitString" => [new TraitString(), new TraitStringProvider()];
+    }
+
+    private function getMixedProvider(): ValueProviderList
+    {
+        return new ValueProviderList(
+            new StringProvider(),
+            new BoolProvider(),
+            new IntProvider(),
+            new FloatProvider(new IntProvider()),
+            new ArrayProvider(),
+            new ObjectProvider(),
+            new CallableProvider(),
+            new NullProvider()
+        );
+    }
+}

--- a/tests/Unit/Constraint/ValueProvider/PseudoValueProviderFactoryTest.php
+++ b/tests/Unit/Constraint/ValueProvider/PseudoValueProviderFactoryTest.php
@@ -43,6 +43,7 @@ use phpDocumentor\Reflection\PseudoTypes\TraitString;
 use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\ArrayKey;
 use phpDocumentor\Reflection\Types\ClassString;
+
 /**
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\PseudoValueProviderFactory
  * @covers ::__construct

--- a/tests/Unit/Constraint/ValueProvider/Scalar/IntProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Scalar/IntProviderTest.php
@@ -9,6 +9,7 @@ use Exception;
 
 /**
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\IntProvider
+ * @covers ::__construct
  */
 class IntProviderTest extends AbstractValueProviderTest
 {
@@ -21,5 +22,21 @@ class IntProviderTest extends AbstractValueProviderTest
         $valueProvider = new IntProvider();
 
         static::assertValueTypes($valueProvider->getValues(), ['integer']);
+    }
+
+    /**
+     * @covers ::getValues
+     * @throws Exception
+     */
+    public function testGetValuesRange(): void
+    {
+        $valueProvider = new IntProvider(0, 5);
+        $values        = $valueProvider->getValues();
+
+        static::assertValueTypes($values, ['integer']);
+        foreach ($values as $value) {
+            static::assertGreaterThanOrEqual(0, $value);
+            static::assertLessThanOrEqual(5, $value);
+        }
     }
 }


### PR DESCRIPTION
Add support for extra pseudo types:
- array-key
- callable-string
- class-string
- html-escaped-string
- int<min,max>
- list
- literal-string
- lowercase-string
- negative-int
- non-empty-lowercase-string
- non-empty-string
- numeric
- numeric-string
- positive-int
- trait-string

Added support for setting array key types