### PR TITLE
Add support for php 8.1 enum typehints

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,16 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Call to static method cases\\(\\) on an unknown class UnitEnum\\.$#"
+			count: 1
+			path: src/Constraint/ValueProvider/Compound/InstanceProvider.php
+
+		-
+			message: "#^PHPDoc tag @var for variable \\$enum contains unknown class UnitEnum\\.$#"
+			count: 1
+			path: src/Constraint/ValueProvider/Compound/InstanceProvider.php
+
+		-
+			message: "#^Class DigitalRevolution\\\\AccessorPairConstraint\\\\Tests\\\\Integration\\\\data\\\\TestEnum not found\\.$#"
+			count: 2
+			path: tests/Unit/Constraint/ValueProvider/Compound/InstanceProviderTest.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,6 @@
+includes:
+	- phpstan-baseline.neon
+
 parameters:
   level: max
   treatPhpDocTypesAsCertain: false

--- a/src/Constraint/ValueProvider/Compound/InstanceProvider.php
+++ b/src/Constraint/ValueProvider/Compound/InstanceProvider.php
@@ -6,6 +6,7 @@ namespace DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Comp
 use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProvider;
 use LogicException;
 use PHPUnit\Framework\MockObject\Generator;
+use UnitEnum;
 
 class InstanceProvider implements ValueProvider
 {
@@ -26,6 +27,13 @@ class InstanceProvider implements ValueProvider
      */
     public function getValues(): array
     {
+        if (PHP_VERSION_ID >= 80100 && enum_exists($this->typehint)) {
+            /** @var UnitEnum $enum */
+            $enum = $this->typehint;
+
+            return $enum::cases();
+        }
+
         $mockGenerator = new Generator();
         $instance      = $mockGenerator->getMock($this->typehint, [], [], '', false);
 

--- a/tests/Integration/data/TestEnum.php
+++ b/tests/Integration/data/TestEnum.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data;
+
+enum TestEnum: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}

--- a/tests/Integration/data/success/Regular/Types/CompoundTypes/EnumProperty.php
+++ b/tests/Integration/data/success/Regular/Types/CompoundTypes/EnumProperty.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\success\Regular\Types\CompoundTypes;
+
+use DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\TestEnum;
+
+if (PHP_VERSION_ID >= 80100) {
+    class EnumProperty
+    {
+        private TestEnum $property;
+
+        public function getProperty(): TestEnum
+        {
+            return $this->property;
+        }
+
+        public function setProperty(TestEnum $property): self
+        {
+            $this->property = $property;
+
+            return $this;
+        }
+    }
+} else {
+    // phpcs:ignore PSR1.Classes.ClassDeclaration.MultipleClasses
+    class EnumProperty
+    {
+    }
+}

--- a/tests/Unit/Constraint/ValueProvider/Compound/InstanceProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Compound/InstanceProviderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValueProvider\Compound;
 
 use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\InstanceProvider;
+use DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\TestEnum;
 use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValueProvider\AbstractValueProviderTest;
 use Exception;
 use Iterator;
@@ -33,7 +34,6 @@ class InstanceProviderTest extends AbstractValueProviderTest
     /**
      * Test that the InstanceProvider returns a correct value
      * When the requested class has a constructor requirement
-     *
      * @covers ::__construct
      * @covers ::getValues
      *
@@ -59,5 +59,24 @@ class InstanceProviderTest extends AbstractValueProviderTest
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage("Unknown class/interface typehint found: unknown");
         new InstanceProvider('unknown');
+    }
+
+    /**
+     * Test getting test cases from an enum
+     *
+     * @covers ::__construct
+     * @covers ::getValues
+     * @throws Exception
+     * @requires PHP >= 8.1
+     */
+    public function testGetEnumValues(): void
+    {
+        $valueProvider = new InstanceProvider(TestEnum::class);
+        $values        = $valueProvider->getValues();
+
+        static::assertNotEmpty($values);
+        foreach ($values as $value) {
+            static::assertInstanceOf(TestEnum::class, $value);
+        }
     }
 }


### PR DESCRIPTION
Kept PHP 7.4 and PHP 8.0 support by adding PHP_VERSION constant checks