### PR TITLE
Add backwards compat support for moved PHPUnit's Generator

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,6 +17,3 @@ parameters:
     html-escaped-string: 'string'
     lowercase-string: 'string'
     non-empty-string: 'string'
-
-  ignoreErrors:
-    - '#on an unknown class PHPUnit\Framework\MockObject\Generator\Generator#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,3 +17,6 @@ parameters:
     html-escaped-string: 'string'
     lowercase-string: 'string'
     non-empty-string: 'string'
+
+  ignoreErrors:
+    - '#on an unknown class PHPUnit\Framework\MockObject\Generator\Generator#'

--- a/src/Constraint/ValueProvider/Compound/InstanceProvider.php
+++ b/src/Constraint/ValueProvider/Compound/InstanceProvider.php
@@ -35,6 +35,7 @@ class InstanceProvider implements ValueProvider
         }
 
         if (class_exists('PHPUnit\Framework\MockObject\Generator\Generator')) {
+            /** @var \PHPUnit\Framework\MockObject\Generator $mockGenerator */
             $mockGenerator = new Generator();
         } else {
             $mockGenerator = new \PHPUnit\Framework\MockObject\Generator();

--- a/src/Constraint/ValueProvider/Compound/InstanceProvider.php
+++ b/src/Constraint/ValueProvider/Compound/InstanceProvider.php
@@ -34,10 +34,10 @@ class InstanceProvider implements ValueProvider
             return $enum::cases();
         }
 
-        if (class_exists('PHPUnit\Framework\MockObject\Generator')) {
-            $mockGenerator = new \PHPUnit\Framework\MockObject\Generator();
-        } else {
+        if (class_exists('PHPUnit\Framework\MockObject\Generator\Generator')) {
             $mockGenerator = new Generator();
+        } else {
+            $mockGenerator = new \PHPUnit\Framework\MockObject\Generator();
         }
         $instance = $mockGenerator->getMock($this->typehint, [], [], '', false);
 

--- a/src/Constraint/ValueProvider/Compound/InstanceProvider.php
+++ b/src/Constraint/ValueProvider/Compound/InstanceProvider.php
@@ -5,7 +5,7 @@ namespace DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Comp
 
 use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProvider;
 use LogicException;
-use PHPUnit\Framework\MockObject\Generator;
+use PHPUnit\Framework\MockObject\Generator\Generator;
 use UnitEnum;
 
 class InstanceProvider implements ValueProvider
@@ -34,8 +34,12 @@ class InstanceProvider implements ValueProvider
             return $enum::cases();
         }
 
-        $mockGenerator = new Generator();
-        $instance      = $mockGenerator->getMock($this->typehint, [], [], '', false);
+        if (class_exists('PHPUnit\Framework\MockObject\Generator')) {
+            $mockGenerator = new \PHPUnit\Framework\MockObject\Generator();
+        } else {
+            $mockGenerator = new Generator();
+        }
+        $instance = $mockGenerator->getMock($this->typehint, [], [], '', false);
 
         return [$instance];
     }

--- a/src/Constraint/ValueProvider/Compound/IntersectionProvider.php
+++ b/src/Constraint/ValueProvider/Compound/IntersectionProvider.php
@@ -56,10 +56,10 @@ class IntersectionProvider implements ValueProvider
             eval($classDefinition);
         }
 
-        if (class_exists('PHPUnit\Framework\MockObject\Generator')) {
-            $mockGenerator = new \PHPUnit\Framework\MockObject\Generator();
-        } else {
+        if (class_exists('PHPUnit\Framework\MockObject\Generator\Generator')) {
             $mockGenerator = new Generator();
+        } else {
+            $mockGenerator = new \PHPUnit\Framework\MockObject\Generator();
         }
         $instance = $mockGenerator->getMockForAbstractClass($className, [], '', false, false);
 

--- a/src/Constraint/ValueProvider/Compound/IntersectionProvider.php
+++ b/src/Constraint/ValueProvider/Compound/IntersectionProvider.php
@@ -5,7 +5,7 @@ namespace DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Comp
 
 use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProvider;
 use phpDocumentor\Reflection\Type;
-use PHPUnit\Framework\MockObject\Generator;
+use PHPUnit\Framework\MockObject\Generator\Generator;
 
 /**
  * @SuppressWarnings(PHPMD.EvalExpression)
@@ -56,8 +56,12 @@ class IntersectionProvider implements ValueProvider
             eval($classDefinition);
         }
 
-        $mockGenerator = new Generator();
-        $instance      = $mockGenerator->getMockForAbstractClass($className, [], '', false, false);
+        if (class_exists('PHPUnit\Framework\MockObject\Generator')) {
+            $mockGenerator = new \PHPUnit\Framework\MockObject\Generator();
+        } else {
+            $mockGenerator = new Generator();
+        }
+        $instance = $mockGenerator->getMockForAbstractClass($className, [], '', false, false);
 
         return [$instance];
     }

--- a/src/Constraint/ValueProvider/Compound/IntersectionProvider.php
+++ b/src/Constraint/ValueProvider/Compound/IntersectionProvider.php
@@ -57,6 +57,7 @@ class IntersectionProvider implements ValueProvider
         }
 
         if (class_exists('PHPUnit\Framework\MockObject\Generator\Generator')) {
+            /** @var \PHPUnit\Framework\MockObject\Generator $mockGenerator */
             $mockGenerator = new Generator();
         } else {
             $mockGenerator = new \PHPUnit\Framework\MockObject\Generator();


### PR DESCRIPTION
PHPUnit 10.2 moved
`PHPUnit\Framework\MockObject\Generator`
to
`PHPUnit\Framework\MockObject\Generator\Generator`.

Added backwards compat support for either.