### PR TITLE
Rename *TestCase classes back to *Test when not abstract

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,4 +13,4 @@ parameters:
 		-
 			message: "#^Class DigitalRevolution\\\\AccessorPairConstraint\\\\Tests\\\\Integration\\\\data\\\\TestEnum not found\\.$#"
 			count: 2
-			path: tests/Unit/Constraint/ValueProvider/Compound/InstanceProviderTestCase.php
+			path: tests/Unit/Constraint/ValueProvider/Compound/InstanceProviderTest.php

--- a/tests/Unit/Constraint/ValueProvider/Compound/ArrayProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Compound/ArrayProviderTest.php
@@ -12,7 +12,7 @@ use Exception;
 /**
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\ArrayProvider
  */
-class ArrayProviderTestCase extends AbstractValueProviderTestCase
+class ArrayProviderTest extends AbstractValueProviderTestCase
 {
     /**
      * @covers ::__construct

--- a/tests/Unit/Constraint/ValueProvider/Compound/CallableProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Compound/CallableProviderTest.php
@@ -9,7 +9,7 @@ use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValueProvider
 /**
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\CallableProvider
  */
-class CallableProviderTestCase extends AbstractValueProviderTestCase
+class CallableProviderTest extends AbstractValueProviderTestCase
 {
     /**
      * @covers ::getValues

--- a/tests/Unit/Constraint/ValueProvider/Compound/InstanceProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Compound/InstanceProviderTest.php
@@ -13,7 +13,7 @@ use LogicException;
 /**
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\InstanceProvider
  */
-class InstanceProviderTestCase extends AbstractValueProviderTestCase
+class InstanceProviderTest extends AbstractValueProviderTestCase
 {
     /**
      * @covers ::__construct

--- a/tests/Unit/Constraint/ValueProvider/Compound/IntersectionProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Compound/IntersectionProviderTest.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValueProvider\Compound;
+
+use Countable;
+use DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\IntersectionProvider;
+use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValueProvider\AbstractValueProviderTestCase;
+use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\Types\Object_;
+use stdClass;
+
+/**
+ * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\IntersectionProvider
+ */
+class IntersectionProviderTest extends AbstractValueProviderTestCase
+{
+    /**
+     * @covers ::__construct
+     * @covers ::getValues
+     */
+    public function testGetValues(): void
+    {
+        $valueProvider = new IntersectionProvider([new Object_(new Fqsen('\\' . stdClass::class)), new Object_(new Fqsen('\\' . Countable::class))]);
+
+        static::assertContainsOnlyInstancesOf(stdClass::class, $valueProvider->getValues());
+        static::assertContainsOnlyInstancesOf(Countable::class, $valueProvider->getValues());
+    }
+}

--- a/tests/Unit/Constraint/ValueProvider/Compound/IterableProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Compound/IterableProviderTest.php
@@ -9,7 +9,7 @@ use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValueProvider
 /**
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\IterableProvider
  */
-class IterableProviderTestCase extends AbstractValueProviderTestCase
+class IterableProviderTest extends AbstractValueProviderTestCase
 {
     /**
      * @covers ::getValues

--- a/tests/Unit/Constraint/ValueProvider/Compound/ObjectProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Compound/ObjectProviderTest.php
@@ -10,7 +10,7 @@ use Exception;
 /**
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\ObjectProvider
  */
-class ObjectProviderTestCase extends AbstractValueProviderTestCase
+class ObjectProviderTest extends AbstractValueProviderTestCase
 {
     /**
      * @covers ::getValues

--- a/tests/Unit/Constraint/ValueProvider/Keyword/FalseProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Keyword/FalseProviderTest.php
@@ -9,7 +9,7 @@ use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValueProvider
 /**
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Keyword\FalseProvider
  */
-class FalseProviderTestCase extends AbstractValueProviderTestCase
+class FalseProviderTest extends AbstractValueProviderTestCase
 {
     /**
      * @covers ::getValues

--- a/tests/Unit/Constraint/ValueProvider/Keyword/TrueProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Keyword/TrueProviderTest.php
@@ -9,7 +9,7 @@ use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValueProvider
 /**
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Keyword\TrueProvider
  */
-class TrueProviderTestCase extends AbstractValueProviderTestCase
+class TrueProviderTest extends AbstractValueProviderTestCase
 {
     /**
      * @covers ::getValues

--- a/tests/Unit/Constraint/ValueProvider/Pseudo/CallableStringProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Pseudo/CallableStringProviderTest.php
@@ -9,7 +9,7 @@ use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValueProvider
 /**
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\CallableStringProvider
  */
-class CallableStringProviderTestCase extends AbstractValueProviderTestCase
+class CallableStringProviderTest extends AbstractValueProviderTestCase
 {
     /**
      * @covers ::getValues

--- a/tests/Unit/Constraint/ValueProvider/Pseudo/ClassStringProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Pseudo/ClassStringProviderTest.php
@@ -10,7 +10,7 @@ use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValueProvider
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\ClassStringProvider
  * @covers ::__construct
  */
-class ClassStringProviderTestCase extends AbstractValueProviderTestCase
+class ClassStringProviderTest extends AbstractValueProviderTestCase
 {
     /**
      * @covers ::getValues

--- a/tests/Unit/Constraint/ValueProvider/Pseudo/HtmlEscapedStringProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Pseudo/HtmlEscapedStringProviderTest.php
@@ -10,7 +10,7 @@ use Exception;
 /**
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\HtmlEscapedStringProvider
  */
-class HtmlEscapedStringProviderTestCase extends AbstractValueProviderTestCase
+class HtmlEscapedStringProviderTest extends AbstractValueProviderTestCase
 {
     /**
      * @covers ::getValues

--- a/tests/Unit/Constraint/ValueProvider/Pseudo/ListProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Pseudo/ListProviderTest.php
@@ -12,7 +12,7 @@ use Exception;
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\ListProvider
  * @covers ::__construct
  */
-class ListProviderTestCase extends AbstractValueProviderTestCase
+class ListProviderTest extends AbstractValueProviderTestCase
 {
     /**
      * @covers ::getValues

--- a/tests/Unit/Constraint/ValueProvider/Pseudo/LiteralStringProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Pseudo/LiteralStringProviderTest.php
@@ -10,7 +10,7 @@ use Exception;
 /**
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\LiteralStringProvider
  */
-class LiteralStringProviderTestCase extends AbstractValueProviderTestCase
+class LiteralStringProviderTest extends AbstractValueProviderTestCase
 {
     /**
      * @covers ::getValues

--- a/tests/Unit/Constraint/ValueProvider/Pseudo/LowercaseStringProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Pseudo/LowercaseStringProviderTest.php
@@ -13,7 +13,7 @@ use Exception;
  * @covers ::__construct
  * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\StringProvider
  */
-class LowercaseStringProviderTestCase extends AbstractValueProviderTestCase
+class LowercaseStringProviderTest extends AbstractValueProviderTestCase
 {
     /**
      * @covers ::getValues

--- a/tests/Unit/Constraint/ValueProvider/Pseudo/NonEmptyStringProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Pseudo/NonEmptyStringProviderTest.php
@@ -13,7 +13,7 @@ use Exception;
  * @covers ::__construct
  * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\StringProvider
  */
-class NonEmptyStringProviderTestCase extends AbstractValueProviderTestCase
+class NonEmptyStringProviderTest extends AbstractValueProviderTestCase
 {
     /**
      * @covers ::getValues

--- a/tests/Unit/Constraint/ValueProvider/Pseudo/NumericStringProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Pseudo/NumericStringProviderTest.php
@@ -10,7 +10,7 @@ use Exception;
 /**
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\NumericStringProvider
  */
-class NumericStringProviderTestCase extends AbstractValueProviderTestCase
+class NumericStringProviderTest extends AbstractValueProviderTestCase
 {
     /**
      * @covers ::getValues

--- a/tests/Unit/Constraint/ValueProvider/Pseudo/TraitStringProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Pseudo/TraitStringProviderTest.php
@@ -9,7 +9,7 @@ use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValueProvider
 /**
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Pseudo\TraitStringProvider
  */
-class TraitStringProviderTestCase extends AbstractValueProviderTestCase
+class TraitStringProviderTest extends AbstractValueProviderTestCase
 {
     /**
      * @covers ::getValues

--- a/tests/Unit/Constraint/ValueProvider/Scalar/BoolProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Scalar/BoolProviderTest.php
@@ -9,7 +9,7 @@ use DigitalRevolution\AccessorPairConstraint\Tests\Unit\Constraint\ValueProvider
 /**
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\BoolProvider
  */
-class BoolProviderTestCase extends AbstractValueProviderTestCase
+class BoolProviderTest extends AbstractValueProviderTestCase
 {
     /**
      * @covers ::getValues

--- a/tests/Unit/Constraint/ValueProvider/Scalar/FloatProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Scalar/FloatProviderTest.php
@@ -12,7 +12,7 @@ use Exception;
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\FloatProvider
  * @uses \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\IntProvider
  */
-class FloatProviderTestCase extends AbstractValueProviderTestCase
+class FloatProviderTest extends AbstractValueProviderTestCase
 {
     /**
      * @covers ::__construct

--- a/tests/Unit/Constraint/ValueProvider/Scalar/IntProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Scalar/IntProviderTest.php
@@ -11,7 +11,7 @@ use Exception;
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\IntProvider
  * @covers ::__construct
  */
-class IntProviderTestCase extends AbstractValueProviderTestCase
+class IntProviderTest extends AbstractValueProviderTestCase
 {
     /**
      * @covers ::getValues

--- a/tests/Unit/Constraint/ValueProvider/Scalar/StringProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Scalar/StringProviderTest.php
@@ -10,7 +10,7 @@ use Exception;
 /**
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Scalar\StringProvider
  */
-class StringProviderTestCase extends AbstractValueProviderTestCase
+class StringProviderTest extends AbstractValueProviderTestCase
 {
     /**
      * @covers ::getValues

--- a/tests/Unit/Constraint/ValueProvider/Special/NullProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Special/NullProviderTest.php
@@ -10,7 +10,7 @@ use Exception;
 /**
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Special\NullProvider
  */
-class NullProviderTestCase extends AbstractValueProviderTestCase
+class NullProviderTest extends AbstractValueProviderTestCase
 {
     /**
      * @covers ::getValues

--- a/tests/Unit/Constraint/ValueProvider/Special/ResourceProviderTest.php
+++ b/tests/Unit/Constraint/ValueProvider/Special/ResourceProviderTest.php
@@ -10,7 +10,7 @@ use Exception;
 /**
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Special\ResourceProvider
  */
-class ResourceProviderTestCase extends AbstractValueProviderTestCase
+class ResourceProviderTest extends AbstractValueProviderTestCase
 {
     /**
      * @covers ::getValues

--- a/tests/Unit/Constraint/ValueProvider/ValueProviderListTest.php
+++ b/tests/Unit/Constraint/ValueProvider/ValueProviderListTest.php
@@ -13,7 +13,7 @@ use LogicException;
 /**
  * @coversDefaultClass \DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\ValueProviderList
  */
-class ValueProviderListTestCase extends AbstractValueProviderTestCase
+class ValueProviderListTest extends AbstractValueProviderTestCase
 {
     /**
      * @covers ::__construct


### PR DESCRIPTION
- Were automatically renamed to testcase before when renaming the abstract parent