### PR TITLE
Add support for renamed get mock method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "scripts": {
         "check": ["@check:phpstan", "@check:phpmd", "@check:phpcs"],
         "check:phpstan": "phpstan analyse",
-        "check:phpmd": "phpmd src,tests text phpmd.xml.dist --suffixes=php --exclude /tests/*/data/*",
+        "check:phpmd": "phpmd src,tests text phpmd.xml.dist --suffixes php --exclude /tests/*/data/*",
         "check:phpcs": "phpcs src tests",
         "fix": "@fix:phpcbf",
         "fix:phpcbf": "phpcbf src tests",

--- a/src/Constraint/ValueProvider/Compound/InstanceProvider.php
+++ b/src/Constraint/ValueProvider/Compound/InstanceProvider.php
@@ -37,10 +37,15 @@ class InstanceProvider implements ValueProvider
         if (class_exists('PHPUnit\Framework\MockObject\Generator\Generator')) {
             /** @var \PHPUnit\Framework\MockObject\Generator $mockGenerator */
             $mockGenerator = new Generator();
+            if (method_exists($mockGenerator, 'testDouble')) {
+                $instance = $mockGenerator->testDouble($this->typehint, true, [], [], '', false);
+            } else {
+                $instance = $mockGenerator->getMock($this->typehint, [], [], '', false);
+            }
         } else {
             $mockGenerator = new \PHPUnit\Framework\MockObject\Generator();
+            $instance      = $mockGenerator->getMock($this->typehint, [], [], '', false);
         }
-        $instance = $mockGenerator->getMock($this->typehint, [], [], '', false);
 
         return [$instance];
     }

--- a/src/Constraint/ValueProvider/Compound/IntersectionProvider.php
+++ b/src/Constraint/ValueProvider/Compound/IntersectionProvider.php
@@ -60,7 +60,7 @@ class IntersectionProvider implements ValueProvider
             /** @var \PHPUnit\Framework\MockObject\Generator $mockGenerator */
             $mockGenerator = new Generator();
             if (method_exists($mockGenerator, 'mockObjectForAbstractClass')) {
-                $instance = $mockGenerator->mockForAbstractClass($className, [], '', false, false);
+                $instance = $mockGenerator->mockObjectForAbstractClass($className, [], '', false, false);
             } else {
                 $instance = $mockGenerator->getMockForAbstractClass($className, [], '', false, false);
             }

--- a/src/Constraint/ValueProvider/Compound/IntersectionProvider.php
+++ b/src/Constraint/ValueProvider/Compound/IntersectionProvider.php
@@ -59,10 +59,15 @@ class IntersectionProvider implements ValueProvider
         if (class_exists('PHPUnit\Framework\MockObject\Generator\Generator')) {
             /** @var \PHPUnit\Framework\MockObject\Generator $mockGenerator */
             $mockGenerator = new Generator();
+            if (method_exists($mockGenerator, 'mockObjectForAbstractClass')) {
+                $instance = $mockGenerator->mockForAbstractClass($className, [], '', false, false);
+            } else {
+                $instance = $mockGenerator->getMockForAbstractClass($className, [], '', false, false);
+            }
         } else {
             $mockGenerator = new \PHPUnit\Framework\MockObject\Generator();
+            $instance = $mockGenerator->getMockForAbstractClass($className, [], '', false, false);
         }
-        $instance = $mockGenerator->getMockForAbstractClass($className, [], '', false, false);
 
         return [$instance];
     }


### PR DESCRIPTION
2 methods were renamed for the Generator class

`getMock` > `testDouble` (+1 additional argument)
https://github.com/sebastianbergmann/phpunit/compare/10.3.5...10.4.0#diff-75a3eeca974a0ce169359a31becc86004ea431fb1811f13e1ff04b06fb926aeaR1208

`getMockForAbstractClass` > `mockObjectForAbstractClass`
https://github.com/sebastianbergmann/phpunit/compare/10.3.5...10.4.0#diff-75a3eeca974a0ce169359a31becc86004ea431fb1811f13e1ff04b06fb926aeaL1328