### PR TITLE
Fix checking the docblock type for a parameter

### DIFF
--- a/src/Constraint/Typehint/PhpDocParser.php
+++ b/src/Constraint/Typehint/PhpDocParser.php
@@ -17,12 +17,12 @@ class PhpDocParser
             return null;
         }
 
-        preg_match('/\*\s*@(?:phpstan|psalm)-param\s+(.*?)\s*(?:\.\.\.)?' . preg_quote('$' . $parameterName, '/') . '/i', $docComment, $matches);
+        preg_match('/\*\s*@(?:phpstan|psalm)-param\s+(.*?)\s*(?:\.\.\.)?' . preg_quote('$' . $parameterName, '/') . '\W/i', $docComment, $matches);
         if (isset($matches[1])) {
             return $this->normalizeDocblock((string)$matches[1]);
         }
 
-        preg_match('/\*\s*@param\s+(.*?)\s*(?:\.\.\.)?' . preg_quote('$' . $parameterName, '/') . '/i', $docComment, $matches);
+        preg_match('/\*\s*@param\s+(.*?)\s*(?:\.\.\.)?' . preg_quote('$' . $parameterName, '/') . '\W/i', $docComment, $matches);
         if (isset($matches[1])) {
             return $this->normalizeDocblock((string)$matches[1]);
         }

--- a/tests/Integration/data/success/Regular/Constructor/MultiParamNameOverlap.php
+++ b/tests/Integration/data/success/Regular/Constructor/MultiParamNameOverlap.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\success\Regular\Constructor;
+
+class MultiParamNameOverlap
+{
+    /** @var string */
+    private $item;
+
+    /** @var string[] */
+    private $itemList;
+
+    /**
+     * @param string[] $itemList
+     */
+    public function __construct(string $item, array $itemList)
+    {
+        $this->item = $item;
+        $this->itemList = $itemList;
+    }
+
+    /**
+     * @return string
+     */
+    public function getItem(): string
+    {
+        return $this->item;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getItemList(): array
+    {
+        return $this->itemList;
+    }
+}

--- a/tests/Unit/Constraint/Typehint/PhpDocParserTest.php
+++ b/tests/Unit/Constraint/Typehint/PhpDocParserTest.php
@@ -93,6 +93,9 @@ class PhpDocParserTest extends TestCase
         yield ['/** @param array$param */', 'array'];
         yield ['/**@param array$param*/', 'array'];
         yield ["/**\n     *@param array\$param\n     */", 'array'];
+
+        // Don't match parameters where the name is a substring of another parameter
+        yield ['/** @param string $paramList */', null];
     }
 
     /**


### PR DESCRIPTION
Fix checking the docblock type for a parameter, where a previous parameter starts with the same string