### PR TITLE
Add custom value provider for types

### DIFF
--- a/src/Constraint/AccessorPairConstraint.php
+++ b/src/Constraint/AccessorPairConstraint.php
@@ -13,6 +13,7 @@ use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Exception;
 use LogicException;
+use phpDocumentor\Reflection\Types\Object_;
 use PHPUnit\Framework\Constraint\Constraint;
 use ReflectionClass;
 use ReflectionMethod;
@@ -284,8 +285,8 @@ class AccessorPairConstraint extends Constraint
         $typehint = $resolver->getParamTypehint($parameter);
 
         $valueProvider = $this->config->getValueProvider();
-        if ($valueProvider !== null) {
-            $value = $valueProvider($typehint);
+        if ($valueProvider !== null && $typehint instanceof Object_) {
+            $value = $valueProvider(ltrim((string)$typehint->getFqsen(), '\\'));
             if ($value !== null) {
                 return [$value];
             }

--- a/src/Constraint/AccessorPairConstraint.php
+++ b/src/Constraint/AccessorPairConstraint.php
@@ -281,6 +281,14 @@ class AccessorPairConstraint extends Constraint
         $resolver = new TypehintResolver($method);
         $typehint = $resolver->getParamTypehint($parameter);
 
+        $valueProvider = $this->config->getValueProvider();
+        if ($valueProvider !== null) {
+            $value = $valueProvider($typehint);
+            if ($value !== null) {
+                return [$value];
+            }
+        }
+
         return $this->valueProviderFactory->getProvider($typehint)->getValues();
     }
 

--- a/src/Constraint/ConstraintConfig.php
+++ b/src/Constraint/ConstraintConfig.php
@@ -25,7 +25,7 @@ class ConstraintConfig
     /** @var null|callable(): mixed[] */
     private $constructorCallback = null;
 
-    /** @var null|(callable(class-string): mixed) */
+    /** @var null|(callable(class-string): ?object) */
     private $valueProvider = null;
 
     public function hasAccessorPairCheck(): bool
@@ -145,7 +145,7 @@ class ConstraintConfig
      * is the class-string of the value, the return value should be the provided value. Return <code>null</code>
      * to skip the value provider and use the default value providers.
      *
-     * @param callable(class-string): mixed $valueProvider
+     * @param callable(class-string): ?object $valueProvider
      */
     public function setValueProvider(callable $valueProvider): self
     {

--- a/src/Constraint/ConstraintConfig.php
+++ b/src/Constraint/ConstraintConfig.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace DigitalRevolution\AccessorPairConstraint\Constraint;
 
-use phpDocumentor\Reflection\Type;
-
 class ConstraintConfig
 {
     /** @var bool */

--- a/src/Constraint/ConstraintConfig.php
+++ b/src/Constraint/ConstraintConfig.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace DigitalRevolution\AccessorPairConstraint\Constraint;
 
+use phpDocumentor\Reflection\Type;
+
 class ConstraintConfig
 {
     /** @var bool */
@@ -22,6 +24,9 @@ class ConstraintConfig
 
     /** @var null|callable(): mixed[] */
     private $constructorCallback = null;
+
+    /** @var null|(callable(Type): mixed) */
+    private $valueProvider = null;
 
     public function hasAccessorPairCheck(): bool
     {
@@ -126,6 +131,25 @@ class ConstraintConfig
     public function setConstructorCallback(callable $callback): self
     {
         $this->constructorCallback = $callback;
+
+        return $this;
+    }
+
+    public function getValueProvider(): ?callable
+    {
+        return $this->valueProvider;
+    }
+
+    /**
+     * Callback function to allow for a custom value provider. For instance for final classes. The argument
+     * is the typehint of the value, the return value should be the provided value. Return <code>null</code>
+     * to skip the value provider and use the default value providers.
+     *
+     * @param callable(Type): mixed $valueProvider
+     */
+    public function setValueProvider(callable $valueProvider): self
+    {
+        $this->valueProvider = $valueProvider;
 
         return $this;
     }

--- a/src/Constraint/ConstraintConfig.php
+++ b/src/Constraint/ConstraintConfig.php
@@ -25,7 +25,7 @@ class ConstraintConfig
     /** @var null|callable(): mixed[] */
     private $constructorCallback = null;
 
-    /** @var null|(callable(Type): mixed) */
+    /** @var null|(callable(class-string): mixed) */
     private $valueProvider = null;
 
     public function hasAccessorPairCheck(): bool
@@ -142,10 +142,10 @@ class ConstraintConfig
 
     /**
      * Callback function to allow for a custom value provider. For instance for final classes. The argument
-     * is the typehint of the value, the return value should be the provided value. Return <code>null</code>
+     * is the class-string of the value, the return value should be the provided value. Return <code>null</code>
      * to skip the value provider and use the default value providers.
      *
-     * @param callable(Type): mixed $valueProvider
+     * @param callable(class-string): mixed $valueProvider
      */
     public function setValueProvider(callable $valueProvider): self
     {

--- a/tests/Integration/AccessorPairAsserterTest.php
+++ b/tests/Integration/AccessorPairAsserterTest.php
@@ -200,13 +200,7 @@ class AccessorPairAsserterTest extends TestCase
     public function testFinalClassWithCustomValueProvider(): void
     {
         $config = new ConstraintConfig();
-        $config->setValueProvider(static function (Type $type) {
-            if ($type instanceof Object_ && (string)$type->getFqsen() !== FinalClass::class) {
-                return new FinalClass();
-            }
-
-            return null;
-        });
+        $config->setValueProvider(static fn(string $class) => $class === FinalClass::class ? new FinalClass() : null);
 
         static::assertAccessorPairs(FinalClass::class, $config);
     }

--- a/tests/Integration/AccessorPairAsserterTest.php
+++ b/tests/Integration/AccessorPairAsserterTest.php
@@ -6,6 +6,7 @@ namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration;
 use DigitalRevolution\AccessorPairConstraint\AccessorPairAsserter;
 use DigitalRevolution\AccessorPairConstraint\Constraint\ConstraintConfig;
 use DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\manual\CustomConstructorParameters;
+use DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\manual\FinalClass;
 use DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\manual\IntersectionClassProperty;
 use DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\manual\IntersectionInterfaceProperty;
 use DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\manual\SetterTransformer;
@@ -13,6 +14,8 @@ use DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\manual\Union
 use DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\manual\UnionProperty;
 use DigitalRevolution\AccessorPairConstraint\Tests\TestCase;
 use Generator;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Object_;
 use PHPUnit\Framework\ExpectationFailedException;
 use ReflectionException;
 use TypeError;
@@ -101,7 +104,6 @@ class AccessorPairAsserterTest extends TestCase
 
     /**
      * When turning off the propertyDefaultCheck, we can safely pass classes we know will fail the constraint
-     *
      * @dataProvider failureInitialStateDataProvider
      */
     public function testExcludingInitialStateCheck(object $class): void
@@ -119,7 +121,6 @@ class AccessorPairAsserterTest extends TestCase
 
     /**
      * When turning off the constructorPairCheck, we can safely pass classes we know will fail the constraint
-     *
      * @dataProvider failureConstructorDataProvider
      */
     public function testExcludingConstructorPair(object $class): void
@@ -194,6 +195,20 @@ class AccessorPairAsserterTest extends TestCase
     {
         // Test a method with an intersection typehint: A&B
         static::assertAccessorPairs(IntersectionClassProperty::class);
+    }
+
+    public function testFinalClassWithCustomValueProvider(): void
+    {
+        $config = new ConstraintConfig();
+        $config->setValueProvider(static function (Type $type) {
+            if ($type instanceof Object_ && (string)$type->getFqsen() !== FinalClass::class) {
+                return new FinalClass();
+            }
+
+            return null;
+        });
+
+        static::assertAccessorPairs(FinalClass::class, $config);
     }
 
     /**

--- a/tests/Integration/AccessorPairAsserterTest.php
+++ b/tests/Integration/AccessorPairAsserterTest.php
@@ -14,8 +14,6 @@ use DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\manual\Union
 use DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\manual\UnionProperty;
 use DigitalRevolution\AccessorPairConstraint\Tests\TestCase;
 use Generator;
-use phpDocumentor\Reflection\Type;
-use phpDocumentor\Reflection\Types\Object_;
 use PHPUnit\Framework\ExpectationFailedException;
 use ReflectionException;
 use TypeError;

--- a/tests/Integration/data/manual/FinalClass.php
+++ b/tests/Integration/data/manual/FinalClass.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalRevolution\AccessorPairConstraint\Tests\Integration\data\manual;
+
+final class FinalClass
+{
+    private int $intValue;
+    private FinalClass $property;
+
+    public function getIntValue(): int
+    {
+        return $this->intValue;
+    }
+
+    public function setIntValue(int $intValue): void
+    {
+        $this->intValue = $intValue;
+    }
+
+    public function getProperty(): FinalClass
+    {
+        return $this->property;
+    }
+
+    public function setProperty(FinalClass $property): void
+    {
+        $this->property = $property;
+    }
+}


### PR DESCRIPTION
Methods that use a final class as setter/getter can't be mocked and hence fail when a value is trying to be provided. Add configuration option to allow a custom value provider based on `class-string`