### PR TITLE
Allow for `Object|null` and `?Object` final class as property type

### DIFF
--- a/src/Constraint/AccessorPairConstraint.php
+++ b/src/Constraint/AccessorPairConstraint.php
@@ -13,6 +13,7 @@ use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Exception;
 use LogicException;
+use phpDocumentor\Reflection\Types\Nullable;
 use phpDocumentor\Reflection\Types\Object_;
 use PHPUnit\Framework\Constraint\Constraint;
 use ReflectionClass;
@@ -285,8 +286,9 @@ class AccessorPairConstraint extends Constraint
         $typehint = $resolver->getParamTypehint($parameter);
 
         $valueProvider = $this->config->getValueProvider();
-        if ($valueProvider !== null && $typehint instanceof Object_) {
-            $value = $valueProvider(ltrim((string)$typehint->getFqsen(), '\\'));
+        $nonNullType   = $typehint instanceof Nullable ? $typehint->getActualType() : $typehint;
+        if ($valueProvider !== null && $nonNullType instanceof Object_) {
+            $value = $valueProvider(ltrim((string)$nonNullType->getFqsen(), '\\'));
             if ($value !== null) {
                 return [$value];
             }

--- a/tests/Integration/data/manual/FinalClass.php
+++ b/tests/Integration/data/manual/FinalClass.php
@@ -8,6 +8,8 @@ final class FinalClass
 {
     private int $intValue;
     private FinalClass $property;
+    private ?FinalClass $nullableProperty = null;
+    private FinalClass|null $nullUnionProperty = null;
 
     public function getIntValue(): int
     {
@@ -27,5 +29,25 @@ final class FinalClass
     public function setProperty(FinalClass $property): void
     {
         $this->property = $property;
+    }
+
+    public function getNullableProperty(): ?FinalClass
+    {
+        return $this->nullableProperty;
+    }
+
+    public function setNullableProperty(?FinalClass $nullableProperty): void
+    {
+        $this->nullableProperty = $nullableProperty;
+    }
+
+    public function getNullUnionProperty(): FinalClass|null
+    {
+        return $this->nullUnionProperty;
+    }
+
+    public function setNullUnionProperty(FinalClass|null $nullUnionProperty): void
+    {
+        $this->nullUnionProperty = $nullUnionProperty;
     }
 }


### PR DESCRIPTION
The custom value provider only supports `private FinalClass $object` and not `private ?FinalClass $object`. This PR adds support for the latter.