### PR TITLE
Fix implicit nullable deprecation for php 8.4

### DIFF
--- a/src/AccessorPairAsserter.php
+++ b/src/AccessorPairAsserter.php
@@ -28,7 +28,7 @@ trait AccessorPairAsserter
      *                                       By default the getter/setter pairs and constructor/getter pairs will be tested
      * @param string                $message Custom PHPUnit error message in case of constraint failure
      */
-    public static function assertAccessorPairs(string $object, ConstraintConfig $config = null, string $message = ''): void
+    public static function assertAccessorPairs(string $object, ?ConstraintConfig $config = null, string $message = ''): void
     {
         if ($config === null) {
             $config = new ConstraintConfig();

--- a/src/Constraint/ValueProvider/Compound/ArrayProvider.php
+++ b/src/Constraint/ValueProvider/Compound/ArrayProvider.php
@@ -14,7 +14,7 @@ class ArrayProvider implements ValueProvider
     public function __construct(?ValueProvider $valueProvider = null, ?ValueProvider $keyProvider = null)
     {
         $this->valueProvider = $valueProvider;
-        $this->keyProvider   = $keyProvider;
+        $this->keyProvider = $keyProvider;
     }
 
     /**
@@ -29,9 +29,10 @@ class ArrayProvider implements ValueProvider
         }
 
         $testArray = [];
-        $values    = $this->getArrayValues();
+        $values = $this->getArrayValues();
         foreach ($values as $i => $value) {
-            $testArray[$keys[$i] ?? $i] = $value;
+            $key = array_key_exists($i, $keys) ? $keys[$i] : $i;
+            $testArray[$key] = $value;
         }
 
         return [$testArray];

--- a/src/Constraint/ValueProvider/Compound/ArrayProvider.php
+++ b/src/Constraint/ValueProvider/Compound/ArrayProvider.php
@@ -31,6 +31,7 @@ class ArrayProvider implements ValueProvider
         $testArray = [];
         $values    = $this->getArrayValues();
         foreach ($values as $i => $value) {
+            /** @phpstan-var array-key[] $keys */
             $testArray[$keys[$i] ?? $i] = $value;
         }
 

--- a/src/Constraint/ValueProvider/Compound/ArrayProvider.php
+++ b/src/Constraint/ValueProvider/Compound/ArrayProvider.php
@@ -14,7 +14,7 @@ class ArrayProvider implements ValueProvider
     public function __construct(?ValueProvider $valueProvider = null, ?ValueProvider $keyProvider = null)
     {
         $this->valueProvider = $valueProvider;
-        $this->keyProvider = $keyProvider;
+        $this->keyProvider   = $keyProvider;
     }
 
     /**
@@ -29,10 +29,9 @@ class ArrayProvider implements ValueProvider
         }
 
         $testArray = [];
-        $values = $this->getArrayValues();
+        $values    = $this->getArrayValues();
         foreach ($values as $i => $value) {
-            $key = array_key_exists($i, $keys) ? $keys[$i] : $i;
-            $testArray[$key] = $value;
+            $testArray[$keys[$i] ?? $i] = $value;
         }
 
         return [$testArray];

--- a/src/Constraint/ValueProvider/Compound/ArrayProvider.php
+++ b/src/Constraint/ValueProvider/Compound/ArrayProvider.php
@@ -11,7 +11,7 @@ class ArrayProvider implements ValueProvider
     protected ?ValueProvider $valueProvider;
     protected ?ValueProvider $keyProvider;
 
-    public function __construct(ValueProvider $valueProvider = null, ValueProvider $keyProvider = null)
+    public function __construct(?ValueProvider $valueProvider = null, ?ValueProvider $keyProvider = null)
     {
         $this->valueProvider = $valueProvider;
         $this->keyProvider   = $keyProvider;

--- a/src/Constraint/ValueProvider/Pseudo/ListProvider.php
+++ b/src/Constraint/ValueProvider/Pseudo/ListProvider.php
@@ -9,7 +9,7 @@ class ListProvider implements ValueProvider
 {
     protected ?ValueProvider $valueProvider;
 
-    public function __construct(ValueProvider $valueProvider = null)
+    public function __construct(?ValueProvider $valueProvider = null)
     {
         $this->valueProvider = $valueProvider;
     }


### PR DESCRIPTION
Fixes the implicit nullable warnings in php 8.4:

src\Constraint\ValueProvider\Compound\ArrayProvider.php:14
DigitalRevolution\AccessorPairConstraint\Constraint\ValueProvider\Compound\ArrayProvider::__construct(): Implicitly marking parameter $valueProvider as nullable is deprecated, the explicit nullable type must be used instead
