### PR TITLE
Support v2.0 for package phpdocumentor/type-resolver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=8.1",
         "doctrine/inflector": "^2.0",
-        "phpdocumentor/type-resolver": "^1.9",
+        "phpdocumentor/type-resolver": "^1.9 || ^2.0",
         "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0"
     },
     "require-dev": {


### PR DESCRIPTION
while upgrading packages higher up the chain, like phpdocumentor/reflection-docblock, type-resolver is blocking the upgrade because of missing type-resolver support for v2.0+

```
- Root composer.json requires phpdocumentor/reflection-docblock ^6.0 -> satisfiable by phpdocumentor/reflection-docblock[6.0.0, 6.0.1, 6.x-dev].
    - digitalrevolution/accessorpair-constraint v2.7.1 requires phpdocumentor/type-resolver ^1.9 -> satisfiable by phpdocumentor/type-resolver[1.9.0, ..., 1.x-dev].
    - phpdocumentor/reflection-docblock[6.0.0, ..., 6.x-dev] require phpdocumentor/type-resolver ^2.0 -> satisfiable by phpdocumentor/type-resolver[2.0.0, 2.x-dev].
    - phpdocumentor/type-resolver 1.9.0 requires phpstan/phpdoc-parser ^1.18 -> found phpstan/phpdoc-parser[1.18.0, ..., 1.33.0] but it conflicts with your root composer.json require (^2.0).
```